### PR TITLE
fix abstract method initialization error

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,7 @@ So you can for example train 4 copies of pettingzoo's pistonball environment in 
 from stable_baselines3 import PPO
 from pettingzoo.butterfly import pistonball_v4
 import supersuit as ss
-env = pistonball_v4.parallel_env(
-    n_pistons=20,
-    local_ratio=0,
-    time_penalty=-0.1,
-    continuous=True,
-    random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)
+env = pistonball_v4.parallel_env()
 env = ss.color_reduction_v0(env, mode='B')
 env = ss.resize_v0(env, x_size=84, y_size=84)
 env = ss.frame_stack_v1(env, 3)

--- a/README.md
+++ b/README.md
@@ -111,15 +111,21 @@ So you can for example train 4 copies of pettingzoo's pistonball environment in 
 
 ```
 from stable_baselines3 import PPO
-from pettingzoo.butterfly import pistonball_v3
-from supersuit import concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0
-
-env = pistonball_v3.parallel_env()
-env = pettingzoo_env_to_vec_env_v0(env)
-env = concat_vec_envs_v0(env, 4, base_class='stable_baselines3')
-
+from pettingzoo.butterfly import pistonball_v4
+import supersuit as ss
+env = pistonball_v4.parallel_env(
+    n_pistons=20,
+    local_ratio=0,
+    time_penalty=-0.1,
+    continuous=True,
+    random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)
+env = ss.color_reduction_v0(env, mode='B')
+env = ss.resize_v0(env, x_size=84, y_size=84)
+env = ss.frame_stack_v1(env, 3)
+env = ss.pettingzoo_env_to_vec_env_v0(env)
+env = ss.concat_vec_envs_v0(env, 8, num_cpus=4, base_class='stable_baselines3')
 model = PPO('CnnPolicy', env, verbose=3, n_steps=16)
-model.learn(total_timesteps=1000000)
+model.learn(total_timesteps=2000000)
 ```
 
 `vectorize_aec_env_v0(aec_env, num_envs, num_cpus=0)` creates an AEC Vector env (API documented in source [here](https://github.com/PettingZoo-Team/SuperSuit/blob/master/supersuit/aec_vector/base_aec_vec_env.py)). `num_cpus=0` indicates that the process will run in a single thread. Values of 1 or more will spawn at most that number of processes.  

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -1,8 +1,7 @@
-from stable_baselines3.common.vec_env.base_vec_env import VecEnv
+from stable_baselines3.common.vec_env import VecEnvWrapper
 import warnings
 
-
-class SB3VecEnvWrapper(VecEnv):
+class SB3VecEnvWrapper(VecEnvWrapper):
     def __init__(self, venv):
         self.venv = venv
         self.num_envs = venv.num_envs
@@ -12,29 +11,5 @@ class SB3VecEnvWrapper(VecEnv):
     def reset(self):
         return self.venv.reset()
 
-    def step_async(self, actions):
-        self.venv.step_async(actions)
-
     def step_wait(self):
         return self.venv.step_wait()
-
-    def step(self, actions):
-        return self.venv.step(actions)
-
-    def close(self):
-        del self.venv
-
-    def seed(self, seed=None):
-        self.venv.seed(seed)
-
-    def get_attr(self, attr_name, indices=None):
-        raise NotImplementedError()
-
-    def set_attr(self, attr_name, value, indices=None):
-        raise NotImplementedError()
-
-    def env_method(self, method_name, *method_args, indices=None, **method_kwargs):
-        raise NotImplementedError()
-
-    def env_is_wrapped(self, wrapper_class, indices):
-        raise NotImplementedError()

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -35,3 +35,6 @@ class SB3VecEnvWrapper(VecEnv):
 
     def env_method(self, method_name, *method_args, indices=None, **method_kwargs):
         raise NotImplementedError()
+
+    def env_is_wrapped(self, wrapper_class, indices):
+        raise NotImplementedError()

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -1,6 +1,7 @@
 from stable_baselines3.common.vec_env import VecEnvWrapper
 import warnings
 
+
 class SB3VecEnvWrapper(VecEnvWrapper):
     def __init__(self, venv):
         self.venv = venv


### PR DESCRIPTION
With the latest version of `stable_baselines3`, `stable_baselines3.common.vec_env.base_vec_env.VecEnv` has an abstract method called `env_is_wrapped`, which is not included in `SB3VecEnvWrapper`. So when trying to run the sb3 code in the readme, it breaks. This PR fixes this problem.

![image](https://user-images.githubusercontent.com/5555347/109465537-5488b480-7a36-11eb-88a8-1c3a6276b5a5.png)


