### PR TITLE
Support vectorized video rendering

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install ubuntu dependencies
+      run: |
+        apt-get install python-opengl
+    - name: Install python dependencies
       run: |
         pip install -r requirements.txt
         pip install flake8 pytest pettingzoo[classic]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ubuntu dependencies
       run: |
-        apt-get install python-opengl
+        sudo apt-get install python-opengl
     - name: Install python dependencies
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,15 +25,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ubuntu dependencies
       run: |
-        sudo apt-get install python-opengl
+        sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
         pip install -r requirements.txt
         pip install flake8 pytest pettingzoo[classic]
-    - name: Lint with flake8
-      run: |
-        pytest
     - name: Test with pytest
+      run: |
+        xvfb-run -s "-screen 0 1400x900x24" pytest
+    - name: Lint with flake8
       run: |
         flake8 supersuit/ --ignore E501,E402,F401,E203
         flake8 test/ --ignore E501,E402,F401,F841

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pettingzoo[butterfly]>=1.6.0
 opencv-python
 cloudpickle
+pyglet

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -13,6 +13,7 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         for i in range(len(vec_envs)):
             if not hasattr(vec_envs[i], "num_envs"):
                 vec_envs[i] = SingleVecEnv([lambda: vec_envs[i]])
+        self.metadata = self.vec_envs[0].metadata
         self.observation_space = vec_envs[0].observation_space
         self.action_space = vec_envs[0].action_space
         tot_num_envs = sum(env.num_envs for env in vec_envs)
@@ -57,3 +58,6 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         dones = np.concatenate(dones, axis=0)
         infos = sum(infos, [])
         return observations, rewards, dones, infos
+
+    def render(self, mode="human"):
+        return self.vec_envs[0].render(mode)

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -61,3 +61,7 @@ class ConcatVecEnv(gym.vector.VectorEnv):
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)
+
+    def close(self):
+        for vec_env in self.vec_envs:
+            vec_env.close()

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -74,3 +74,6 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
 
     def render(self, mode="human"):
         return self.par_env.render(mode)
+
+    def close(self):
+        return self.par_env.close()

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -15,6 +15,7 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
         rewards, dones, etc, and will reset environment automatically when it finishes
         """
         self.par_env = par_env
+        self.metadata = par_env.metadata
         self.observation_space = list(par_env.observation_spaces.values())[0]
         self.action_space = list(par_env.action_spaces.values())[0]
         assert all(
@@ -70,3 +71,6 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
             self.black_death or self.par_env.agents == self.par_env.possible_agents
         ), "MarkovVectorEnv does not support environments with varying numbers of active agents unless black_death is set to True"
         return observations, rews, dns, infs
+
+    def render(self, mode="human"):
+        return self.par_env.render(mode)

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -170,4 +170,3 @@ class ProcConcatVec(gym.vector.VectorEnv):
                 pass
         for proc in self.procs:
             proc.join()
-

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -8,6 +8,7 @@ class SingleVecEnv:
         self.observation_space = self.gym_env.observation_space
         self.action_space = self.gym_env.action_space
         self.num_envs = 1
+        self.metadata = self.gym_env.metadata
 
     def reset(self):
         return np.expand_dims(self.gym_env.reset(), 0)


### PR DESCRIPTION
Hello, this PR enables the video recording through `VecVideoRecorder` from sb3. Below is an example code:

```
from stable_baselines3 import PPO
from pettingzoo.butterfly import pistonball_v4
from stable_baselines3.common.vec_env import VecVideoRecorder
import supersuit as ss
import time
env = pistonball_v4.parallel_env()
env = ss.color_reduction_v0(env, mode='B')
env = ss.resize_v0(env, x_size=84, y_size=84)
env = ss.frame_stack_v1(env, 3)
env = ss.pettingzoo_env_to_vec_env_v0(env)
env = ss.concat_vec_envs_v0(env, 8, num_cpus=1, base_class='stable_baselines3')
env = VecVideoRecorder(
    env, f'videos/{time.time()}',
    record_video_trigger=lambda x: x % 1000 == 0, video_length=20)
model = PPO('CnnPolicy', env, verbose=3, n_steps=16, device="cpu")
model.learn(total_timesteps=2000000)
```

It will be great to incorporate this code. Being selfish for a second, this change will help me record the videos of agents playing the game throughout training, much like my experiments with the procgen env. https://wandb.ai/cleanrl/cleanrl.benchmark/reports/Procgen-New--Vmlldzo0NDUyMTg


![d](https://user-images.githubusercontent.com/5555347/109553182-b8e05e00-7aa0-11eb-981c-f0470585ac24.gif)

