### PR TITLE
Env wrapped solution

### DIFF
--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -65,3 +65,6 @@ class ConcatVecEnv(gym.vector.VectorEnv):
     def close(self):
         for vec_env in self.vec_envs:
             vec_env.close()
+
+    def env_is_wrapped(self, wrapper_class):
+        return sum([sub_venv.env_is_wrapped(wrapper_class) for sub_venv in self.vec_envs], [])

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -82,3 +82,10 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
 
     def close(self):
         return self.par_env.close()
+
+    def env_is_wrapped(self, wrapper_class):
+        '''
+        env_is_wrapped only suppors vector and gym environments
+        currently, not pettingzoo environments
+        '''
+        return [False] * self.num_envs

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -55,11 +55,11 @@ def async_loop(vec_env_constr, inpt_p, pipe, shared_obs, shared_actions, shared_
                     if data == "rgb_array":
                         comp_infos = render_result
                 else:
-                    raise AssertionError("bad tuple instruction name: "+name)
+                    raise AssertionError("bad tuple instruction name: " + name)
             elif instr == "terminate":
                 return
             else:
-                raise AssertionError("bad instruction: "+instr)
+                raise AssertionError("bad instruction: " + instr)
             pipe.send(comp_infos)
     except BaseException as e:
         tb = traceback.format_exc()

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -48,12 +48,18 @@ def async_loop(vec_env_constr, inpt_p, pipe, shared_obs, shared_actions, shared_
                 name, data = instr
                 if name == "seed":
                     vec_env.seed(data)
+                elif name == "env_is_wrapped":
+                    comp_infos = vec_env.env_is_wrapped(data)
                 elif name == "render":
                     render_result = vec_env.render(data)
                     if data == "rgb_array":
                         comp_infos = render_result
+                else:
+                    raise AssertionError("bad tuple instruction name: "+name)
             elif instr == "terminate":
                 return
+            else:
+                raise AssertionError("bad instruction: "+instr)
             pipe.send(comp_infos)
     except BaseException as e:
         tb = traceback.format_exc()
@@ -172,3 +178,10 @@ class ProcConcatVec(gym.vector.VectorEnv):
                 pipe.recv()
             except EOFError:
                 raise RuntimeError("only one multiproccessing vector environment can open a window over the duration of a process")
+
+    def env_is_wrapped(self, wrapper_class, indices=None):
+        for i, pipe in enumerate(self.pipes):
+            pipe.send(("env_is_wrapped", wrapper_class))
+
+        results = self._receive_info()
+        return sum(results, [])

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -15,6 +15,6 @@ class SB3VecEnvWrapper(VecEnvWrapper):
     def step_wait(self):
         return self.venv.step_wait()
 
-    def env_is_wrapped(self, wrapper_class, indices):
-        n_returns = len(indices) if indices is not None else self.num_envs
-        return [False] * n_returns
+    def env_is_wrapped(self, wrapper_class, indices=None):
+        # ignores indicies
+        return self.venv.env_is_wrapped(wrapper_class)

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -14,3 +14,7 @@ class SB3VecEnvWrapper(VecEnvWrapper):
 
     def step_wait(self):
         return self.venv.step_wait()
+
+    def env_is_wrapped(self, wrapper_class, indices):
+        n_returns = len(indices) if indices is not None else self.num_envs
+        return [False] * n_returns

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -1,4 +1,5 @@
 import numpy as np
+import gym
 
 
 class SingleVecEnv:
@@ -37,3 +38,11 @@ class SingleVecEnv:
         dones = np.array([done], dtype=np.uint8)
         infos = [info]
         return observations, rewards, dones, infos
+
+    def env_is_wrapped(self, wrapper_class):
+        env_tmp = self.gym_env
+        while isinstance(env_tmp, gym.Wrapper):
+            if isinstance(env_tmp, wrapper_class):
+                return [True]
+            env_tmp = env_tmp.env
+        return [False]

--- a/test/test_vector/test_env_is_wrapped.py
+++ b/test/test_vector/test_env_is_wrapped.py
@@ -11,11 +11,13 @@ def test_env_is_wrapped_true():
     venv1 = concat_vec_envs_v0(env, num_envs)
     assert venv1.env_is_wrapped(flatten) == [True] * 3
 
+
 def test_env_is_wrapped_false():
     env = gym.make("Pendulum-v0")
     num_envs = 3
     venv1 = concat_vec_envs_v0(env, num_envs)
     assert venv1.env_is_wrapped(flatten) == [False] * 3
+
 
 def test_env_is_wrapped_cpu():
     env = gym.make("Pendulum-v0")
@@ -23,6 +25,7 @@ def test_env_is_wrapped_cpu():
     num_envs = 3
     venv1 = concat_vec_envs_v0(env, num_envs, num_cpus=2)
     assert venv1.env_is_wrapped(flatten) == [True] * 3
+
 
 def test_env_is_wrapped_pettingzoo():
     env = simple_spread_v2.parallel_env()

--- a/test/test_vector/test_env_is_wrapped.py
+++ b/test/test_vector/test_env_is_wrapped.py
@@ -1,0 +1,32 @@
+from supersuit import concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0
+from supersuit.gym_wrappers import flatten
+import gym
+from pettingzoo.mpe import simple_spread_v2
+
+
+def test_env_is_wrapped_true():
+    env = gym.make("Pendulum-v0")
+    env = flatten(env)
+    num_envs = 3
+    venv1 = concat_vec_envs_v0(env, num_envs)
+    assert venv1.env_is_wrapped(flatten) == [True] * 3
+
+def test_env_is_wrapped_false():
+    env = gym.make("Pendulum-v0")
+    num_envs = 3
+    venv1 = concat_vec_envs_v0(env, num_envs)
+    assert venv1.env_is_wrapped(flatten) == [False] * 3
+
+def test_env_is_wrapped_cpu():
+    env = gym.make("Pendulum-v0")
+    env = flatten(env)
+    num_envs = 3
+    venv1 = concat_vec_envs_v0(env, num_envs, num_cpus=2)
+    assert venv1.env_is_wrapped(flatten) == [True] * 3
+
+def test_env_is_wrapped_pettingzoo():
+    env = simple_spread_v2.parallel_env()
+    venv1 = pettingzoo_env_to_vec_env_v0(env)
+    num_envs = 3
+    venv1 = concat_vec_envs_v0(venv1, num_envs)
+    assert venv1.env_is_wrapped(flatten) == [False] * 9


### PR DESCRIPTION
Now this has full tested support for gym environments. Still just returns False for pettingzoo environments due to additional complexity inherent with wrappers in that space.

Should completely fix the problem you ran into @jkterry1. Note that while it does not support pettingzoo environments, your use case does not really need this function to do anything at all (it just needs it not to crash). That is because for multi-environment evaluation, the vector environment should just be wrapped with a VectorMonitor wrapper before evaluation. 