### PR TITLE
Added warpper for observation_spaces

### DIFF
--- a/supersuit/generic_wrappers/utils/shared_wrapper_util.py
+++ b/supersuit/generic_wrappers/utils/shared_wrapper_util.py
@@ -16,6 +16,15 @@ class shared_wrapper_aec(PettingzooWrap):
     def observation_space(self, agent):
         return self.modifiers[agent].modify_obs_space(self.env.observation_space(agent))
 
+    @property
+    def observation_spaces(self):
+        # NOTE: this is going to get deprecated in base class
+        observations = {
+            agent: self.modifiers[agent].modify_obs_space(obs)
+            for agent, obs in self.env.observation_spaces.items()
+        }
+        return observations
+
     def action_space(self, agent):
         return self.modifiers[agent].modify_action_space(self.env.action_space(agent))
 
@@ -67,6 +76,15 @@ class shared_wrapper_parr(BaseParallelWraper):
 
     def observation_space(self, agent):
         return self.modifiers[agent].modify_obs_space(self.env.observation_space(agent))
+
+    @property
+    def observation_spaces(self):
+        # NOTE: this is going to get deprecated in base class
+        observations = {
+            agent: self.modifiers[agent].modify_obs_space(obs)
+            for agent, obs in self.env.observation_spaces.items()
+        }
+        return observations
 
     def action_space(self, agent):
         return self.modifiers[agent].modify_action_space(self.env.action_space(agent))


### PR DESCRIPTION
We do not wrap observation_spaces properly since #107 . 

For example, if we use this to wrap the environment from [tutorial](https://towardsdatascience.com/multi-agent-deep-reinforcement-learning-in-15-lines-of-code-using-pettingzoo-e0b963c0820b)
```
ss.frame_stack_v1(env, 3)
```

We will see:
```
(Pdb) p list(env.observation_spaces.values())[0].shape
(84, 84)
(Pdb) p env.observation_space('piston_0').shape
(84, 84, 3)
```

This might not be a complete fix, as there seems that `action_spaces` patch was also removed in #107 

Fixes https://github.com/Farama-Foundation/PettingZoo/issues/512