### PR TITLE
Make the SB3 wrappers return copies of buffers instead of the underlying buffers.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install -r requirements.txt
-        pip install flake8 pytest stable_baselines3 pettingzoo[classic] atari_py magent
+        pip install flake8 pytest stable_baselines3 pettingzoo[classic]>=1.13.1 atari_py magent
     - name: Test with pytest
       run: |
         xvfb-run -s "-screen 0 1400x900x24" pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,8 +28,7 @@ jobs:
         sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
-        pip install -r requirements.txt
-        pip install flake8 pytest stable_baselines3 pettingzoo[classic]>=1.13.1 atari_py magent
+        pip install flake8 pytest stable_baselines3 pettingzoo[classic]>=1.13.1 atari_py magent -r requirements.txt
     - name: Test with pytest
       run: |
         xvfb-run -s "-screen 0 1400x900x24" pytest

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ These functions turn plain Gym environments into vectorized environments, for ev
 
 `stable_baselines3_vec_env_v0(env, num_envs, multiprocessing=False)` creates a stable_baselines vector environment with num_envs copies of the environment. If `multiprocessing` is True, SubprocVecEnv is used instead of DummyVecEnv. Needs stable_baselines3 to be installed to work.
 
-`concat_vec_envs_v0(vec_env, num_vec_envs, num_cpus=0, base_class='gym')` takes in an `vec_env` which is vector environment (should not have multithreading enabled). Creates a new vector environment with `num_vec_envs` copies of that vector environment concatenated together and runs them on `num_cpus` cpus as balanced as possible between cpus. `num_cpus=0` or `num_cpus=1` means to create 0 new threads, i.e. run the process in an efficient single threaded manner. A use case for this function is given below. If the base class of the resulting vector environment matters as it does for stable baselines, you can use the `base_class` parameter to switch between `"gym"` base class and `"stable_baselines3"`'s base class. Note that both have identical functionality.
+`concat_vec_envs_v1(vec_env, num_vec_envs, num_cpus=0, base_class='gym')` takes in an `vec_env` which is vector environment (should not have multithreading enabled). Creates a new vector environment with `num_vec_envs` copies of that vector environment concatenated together and runs them on `num_cpus` cpus as balanced as possible between cpus. `num_cpus=0` or `num_cpus=1` means to create 0 new threads, i.e. run the process in an efficient single threaded manner. A use case for this function is given below. If the base class of the resulting vector environment matters as it does for stable baselines, you can use the `base_class` parameter to switch between `"gym"` base class and `"stable_baselines3"`'s base class. Note that both have identical functionality.
 
 ### Parallel Environment vectorization
 
@@ -116,7 +116,7 @@ The following function performs this conversion.
 
 `pettingzoo_env_to_vec_env_v0(env)`: Takes a PettingZoo ParallelEnv with the following assumptions: no agent death or generation, homogeneous action and observation spaces. Returns a gym vector environment where each "environment" in the vector represents one agent. An arbitrary PettingZoo parallel environment can be enforced to have these assumptions by wrapping it with the pad_action_space, pad_observations, and the black_death wrapper). This conversion to a vector environment can be used to train appropriate pettingzoo environments with standard single agent RL methods such as stable baselines's A2C out of box (example below).
 
-You can also use the `concat_vec_envs_v0` functionality to train on several vector environments in parallel, forming a vector which looks like
+You can also use the `concat_vec_envs_v1` functionality to train on several vector environments in parallel, forming a vector which looks like
 
 ```
 env_1_agent_1
@@ -139,7 +139,7 @@ env = ss.color_reduction_v0(env, mode='B')
 env = ss.resize_v0(env, x_size=84, y_size=84)
 env = ss.frame_stack_v1(env, 3)
 env = ss.pettingzoo_env_to_vec_env_v0(env)
-env = ss.concat_vec_envs_v0(env, 8, num_cpus=4, base_class='stable_baselines3')
+env = ss.concat_vec_envs_v1(env, 8, num_cpus=4, base_class='stable_baselines3')
 model = PPO('CnnPolicy', env, verbose=3, n_steps=16)
 model.learn(total_timesteps=2000000)
 ```

--- a/supersuit/__init__.py
+++ b/supersuit/__init__.py
@@ -8,7 +8,7 @@ from supersuit.generic_wrappers import frame_skip_v0, color_reduction_v0, resize
     sticky_actions_v0 # NOQA
 
 from .vector.vector_constructors import gym_vec_env_v0, stable_baselines_vec_env_v0, \
-    stable_baselines3_vec_env_v0, concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0 # NOQA
+    stable_baselines3_vec_env_v0, concat_vec_envs_v1, pettingzoo_env_to_vec_env_v0 # NOQA
 
 from .aec_vector import vectorize_aec_env_v0 # NOQA
 

--- a/supersuit/__init__.py
+++ b/supersuit/__init__.py
@@ -8,7 +8,7 @@ from supersuit.generic_wrappers import frame_skip_v0, color_reduction_v0, resize
     sticky_actions_v0 # NOQA
 
 from .vector.vector_constructors import gym_vec_env_v0, stable_baselines_vec_env_v0, \
-    stable_baselines3_vec_env_v0, concat_vec_envs_v1, pettingzoo_env_to_vec_env_v0 # NOQA
+    stable_baselines3_vec_env_v0, concat_vec_envs_v1, pettingzoo_env_to_vec_env_v1 # NOQA
 
 from .aec_vector import vectorize_aec_env_v0 # NOQA
 

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -26,7 +26,7 @@ class ConcatVecEnv(gym.vector.VectorEnv):
             endidx = idx + venv.num_envs
             self.obs_buffer[idx:endidx] = obs
             idx = endidx
-        return self.obs_buffer
+        return self.obs_buffer.copy()
 
     def seed(self, seed=None):
         if seed is None:

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -43,7 +43,7 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
                     raise AssertionError("environment has agent death. Not allowed for pettingzoo_env_to_vec_env_v0 unless black_death is True")
                 self.obs_buffer[i] = obs_dict[agent]
 
-        return self.obs_buffer
+        return self.obs_buffer.copy()
 
     def step_async(self, actions):
         self._saved_actions = actions

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -40,7 +40,7 @@ class MarkovVectorEnv(gym.vector.VectorEnv):
                     self.obs_buffer[i] = obs_dict[agent]
             else:
                 if agent not in obs_dict:
-                    raise AssertionError("environment has agent death. Not allowed for pettingzoo_env_to_vec_env_v0 unless black_death is True")
+                    raise AssertionError("environment has agent death. Not allowed for pettingzoo_env_to_vec_env_v1 unless black_death is True")
                 self.obs_buffer[i] = obs_dict[agent]
 
         return self.obs_buffer.copy()

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -1,3 +1,5 @@
+import copy
+
 from .utils.shared_array import SharedArray
 from .utils.space_wrapper import SpaceWrapper
 import multiprocessing as mp
@@ -114,7 +116,7 @@ class ProcConcatVec(gym.vector.VectorEnv):
         self._receive_info()
 
         observations = self.shared_obs.np_arr
-        return observations
+        return observations.copy()
 
     def step_async(self, actions):
         self.shared_act.np_arr[:] = actions
@@ -138,7 +140,7 @@ class ProcConcatVec(gym.vector.VectorEnv):
         observations = self.shared_obs.np_arr
         rewards = self.shared_rews.np_arr
         dones = self.shared_dones.np_arr
-        return observations, rewards, dones, infos
+        return observations.copy(), rewards.copy(), dones.copy(), copy.deepcopy(infos)
 
     def step(self, actions):
         self.step_async(actions)

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -44,7 +44,7 @@ def stable_baselines3_vec_env_v0(env, num_envs, multiprocessing=False):
     return constructor(*args)
 
 
-def concat_vec_envs_v0(vec_env, num_vec_envs, num_cpus=0, base_class='gym'):
+def concat_vec_envs_v1(vec_env, num_vec_envs, num_cpus=0, base_class='gym'):
     num_cpus = min(num_cpus, num_vec_envs)
     vec_env = MakeCPUAsyncConstructor(num_cpus)(*vec_env_args(vec_env, num_vec_envs))
 

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -60,7 +60,7 @@ def concat_vec_envs_v1(vec_env, num_vec_envs, num_cpus=0, base_class='gym'):
         raise ValueError("supersuit_vec_env only supports 'gym', 'stable_baselines', and 'stable_baselines3' for its base_class")
 
 
-def pettingzoo_env_to_vec_env_v0(parallel_env):
+def pettingzoo_env_to_vec_env_v1(parallel_env):
     assert isinstance(parallel_env, ParallelEnv), "pettingzoo_env_to_vec_env takes in a pettingzoo ParallelEnv. Can create a parallel_env with pistonball.parallel_env() or convert it from an AEC env with `from pettingzoo.utils.conversions import to_parallel; to_parallel(env)``"
     assert hasattr(parallel_env, 'possible_agents'), "environment passed to pettingzoo_env_to_vec_env must have possible_agents attribute."
     return MarkovVectorEnv(parallel_env)

--- a/test/generated_agents_test.py
+++ b/test/generated_agents_test.py
@@ -83,7 +83,7 @@ wrapper_fns = [
     lambda: supersuit.pad_action_space_v0(generated_agents_parallel_v0.parallel_env()),
     lambda: supersuit.pad_observations_v0(generated_agents_parallel_v0.parallel_env()),
     lambda: supersuit.agent_indicator_v0(generated_agents_parallel_v0.parallel_env()),
-    lambda: supersuit.pettingzoo_env_to_vec_env_v0(generated_agents_parallel_v0.parallel_env()),
+    lambda: supersuit.pettingzoo_env_to_vec_env_v1(generated_agents_parallel_v0.parallel_env()),
 ]
 
 

--- a/test/test_vector/test_env_is_wrapped.py
+++ b/test/test_vector/test_env_is_wrapped.py
@@ -1,4 +1,4 @@
-from supersuit import concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0
+from supersuit import concat_vec_envs_v1, pettingzoo_env_to_vec_env_v1
 from supersuit.generic_wrappers.frame_skip import frame_skip_gym
 import gym
 from pettingzoo.mpe import simple_spread_v2
@@ -8,14 +8,14 @@ def test_env_is_wrapped_true():
     env = gym.make("MountainCarContinuous-v0")
     env = frame_skip_gym(env, 4)
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs)
+    venv1 = concat_vec_envs_v1(env, num_envs)
     assert venv1.env_is_wrapped(frame_skip_gym) == [True] * 3
 
 
 def test_env_is_wrapped_false():
     env = gym.make("MountainCarContinuous-v0")
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs)
+    venv1 = concat_vec_envs_v1(env, num_envs)
     assert venv1.env_is_wrapped(frame_skip_gym) == [False] * 3
 
 
@@ -23,13 +23,13 @@ def test_env_is_wrapped_cpu():
     env = gym.make("MountainCarContinuous-v0")
     env = frame_skip_gym(env, 4)
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs, num_cpus=2)
+    venv1 = concat_vec_envs_v1(env, num_envs, num_cpus=2)
     assert venv1.env_is_wrapped(frame_skip_gym) == [True] * 3
 
 
 def test_env_is_wrapped_pettingzoo():
     env = simple_spread_v2.parallel_env()
-    venv1 = pettingzoo_env_to_vec_env_v0(env)
+    venv1 = pettingzoo_env_to_vec_env_v1(env)
     num_envs = 3
-    venv1 = concat_vec_envs_v0(venv1, num_envs)
+    venv1 = concat_vec_envs_v1(venv1, num_envs)
     assert venv1.env_is_wrapped(frame_skip_gym) == [False] * 9

--- a/test/test_vector/test_gym_vector.py
+++ b/test/test_vector/test_gym_vector.py
@@ -1,6 +1,6 @@
 import copy
 
-from supersuit import gym_vec_env_v0, stable_baselines3_vec_env_v0, concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0
+from supersuit import gym_vec_env_v0, stable_baselines3_vec_env_v0, concat_vec_envs_v1, pettingzoo_env_to_vec_env_v1
 from pettingzoo.mpe import simple_spread_v2
 import gym
 import numpy as np
@@ -46,14 +46,14 @@ def check_vec_env_equivalency(venv1, venv2, check_info=True):
 def test_gym_supersuit_equivalency():
     env = gym.make("MountainCarContinuous-v0")
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs)
+    venv1 = concat_vec_envs_v1(env, num_envs)
     venv2 = gym_vec_env_v0(env, num_envs)
     check_vec_env_equivalency(venv1, venv2)
 
 
 def test_inital_state_dissimilarity():
     env = gym.make("CartPole-v0")
-    venv = concat_vec_envs_v0(env, 2)
+    venv = concat_vec_envs_v1(env, 2)
     observations = venv.reset()
     assert not np.equal(observations[0], observations[1]).all()
 
@@ -69,24 +69,24 @@ def test_inital_state_dissimilarity():
 def test_mutliproc_single_proc_equivalency():
     env = gym.make("CartPole-v0")
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs, num_cpus=0)  # uses single threaded vector environment
-    venv2 = concat_vec_envs_v0(env, num_envs, num_cpus=4)  # uses multiprocessing vector environment
+    venv1 = concat_vec_envs_v1(env, num_envs, num_cpus=0)  # uses single threaded vector environment
+    venv2 = concat_vec_envs_v1(env, num_envs, num_cpus=4)  # uses multiprocessing vector environment
     check_vec_env_equivalency(venv1, venv2)
 
 
 def test_multiagent_mutliproc_single_proc_equivalency():
     env = simple_spread_v2.parallel_env(max_cycles=10)
-    env = pettingzoo_env_to_vec_env_v0(env)
+    env = pettingzoo_env_to_vec_env_v1(env)
     num_envs = 3
-    venv1 = concat_vec_envs_v0(env, num_envs, num_cpus=0)  # uses single threaded vector environment
-    venv2 = concat_vec_envs_v0(env, num_envs, num_cpus=4)  # uses multiprocessing vector environment
+    venv1 = concat_vec_envs_v1(env, num_envs, num_cpus=0)  # uses single threaded vector environment
+    venv2 = concat_vec_envs_v1(env, num_envs, num_cpus=4)  # uses multiprocessing vector environment
     check_vec_env_equivalency(venv1, venv2)
 
 
 def test_multiproc_buffer():
     num_envs = 2
     env = gym.make("CartPole-v0")
-    env = concat_vec_envs_v0(env, num_envs, num_cpus=2)
+    env = concat_vec_envs_v1(env, num_envs, num_cpus=2)
 
     obss = env.reset()
     for i in range(55):

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -30,13 +30,13 @@ def test_good_env():
             assert all(dones)
         obss = new_obss
 
+
 def test_good_vecenv():
     num_envs = 2
     env = simple_spread_v2.parallel_env()
     max_num_agents = len(env.possible_agents) * num_envs
     env = pettingzoo_env_to_vec_env_v0(env)
     env = concat_vec_envs_v0(env, num_envs)
-
 
     obss = env.reset()
     for i in range(55):

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -1,6 +1,8 @@
+import copy
+
 from pettingzoo.mpe import simple_spread_v2, simple_world_comm_v2
 from pettingzoo.butterfly import knights_archers_zombies_v7
-from supersuit import pettingzoo_env_to_vec_env_v0, black_death_v2
+from supersuit import pettingzoo_env_to_vec_env_v0, black_death_v2, concat_vec_envs_v0
 import pytest
 
 
@@ -10,17 +12,49 @@ def test_good_env():
     env = pettingzoo_env_to_vec_env_v0(env)
     assert env.num_envs == max_num_agents
 
-    env.reset()
+    obss = env.reset()
     for i in range(55):
         actions = [env.action_space.sample() for i in range(env.num_envs)]
-        obss, rews, dones, infos = env.step(actions)
-        assert len(obss) == max_num_agents
+
+        # Check we're not passing a thing that gets mutated
+        keep_obs = copy.deepcopy(obss)
+        new_obss, rews, dones, infos = env.step(actions)
+
+        assert hash(str(keep_obs)) == hash(str(obss))
+        assert len(new_obss) == max_num_agents
         assert len(rews) == max_num_agents
         assert len(dones) == max_num_agents
         assert len(infos) == max_num_agents
         # no agent death, only env death
         if any(dones):
             assert all(dones)
+        obss = new_obss
+
+def test_good_vecenv():
+    num_envs = 2
+    env = simple_spread_v2.parallel_env()
+    max_num_agents = len(env.possible_agents) * num_envs
+    env = pettingzoo_env_to_vec_env_v0(env)
+    env = concat_vec_envs_v0(env, num_envs)
+
+
+    obss = env.reset()
+    for i in range(55):
+        actions = [env.action_space.sample() for i in range(env.num_envs)]
+
+        # Check we're not passing a thing that gets mutated
+        keep_obs = copy.deepcopy(obss)
+        new_obss, rews, dones, infos = env.step(actions)
+
+        assert hash(str(keep_obs)) == hash(str(obss))
+        assert len(new_obss) == max_num_agents
+        assert len(rews) == max_num_agents
+        assert len(dones) == max_num_agents
+        assert len(infos) == max_num_agents
+        # no agent death, only env death
+        if any(dones):
+            assert all(dones)
+        obss = new_obss
 
 
 def test_bad_action_spaces_env():

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -2,14 +2,14 @@ import copy
 
 from pettingzoo.mpe import simple_spread_v2, simple_world_comm_v2
 from pettingzoo.butterfly import knights_archers_zombies_v7
-from supersuit import pettingzoo_env_to_vec_env_v0, black_death_v2, concat_vec_envs_v0
+from supersuit import pettingzoo_env_to_vec_env_v1, black_death_v2, concat_vec_envs_v1
 import pytest
 
 
 def test_good_env():
     env = simple_spread_v2.parallel_env()
     max_num_agents = len(env.possible_agents)
-    env = pettingzoo_env_to_vec_env_v0(env)
+    env = pettingzoo_env_to_vec_env_v1(env)
     assert env.num_envs == max_num_agents
 
     obss = env.reset()
@@ -35,8 +35,8 @@ def test_good_vecenv():
     num_envs = 2
     env = simple_spread_v2.parallel_env()
     max_num_agents = len(env.possible_agents) * num_envs
-    env = pettingzoo_env_to_vec_env_v0(env)
-    env = concat_vec_envs_v0(env, num_envs)
+    env = pettingzoo_env_to_vec_env_v1(env)
+    env = concat_vec_envs_v1(env, num_envs)
 
     obss = env.reset()
     for i in range(55):
@@ -60,12 +60,12 @@ def test_good_vecenv():
 def test_bad_action_spaces_env():
     env = simple_world_comm_v2.parallel_env()
     with pytest.raises(AssertionError):
-        env = pettingzoo_env_to_vec_env_v0(env)
+        env = pettingzoo_env_to_vec_env_v1(env)
 
 
 def test_env_black_death_assertion():
     env = knights_archers_zombies_v7.parallel_env(spawn_rate=50, max_cycles=2000)
-    env = pettingzoo_env_to_vec_env_v0(env)
+    env = pettingzoo_env_to_vec_env_v1(env)
     with pytest.raises(AssertionError):
         for i in range(100):
             env.reset()
@@ -77,7 +77,7 @@ def test_env_black_death_assertion():
 def test_env_black_death_wrapper():
     env = knights_archers_zombies_v7.parallel_env(spawn_rate=50, max_cycles=300)
     env = black_death_v2(env)
-    env = pettingzoo_env_to_vec_env_v0(env)
+    env = pettingzoo_env_to_vec_env_v1(env)
     env.reset()
     for i in range(300):
         actions = [env.action_space.sample() for i in range(env.num_envs)]

--- a/test/test_vector/test_render.py
+++ b/test/test_vector/test_render.py
@@ -2,19 +2,19 @@ from supersuit import gym_vec_env_v0
 import gym
 import numpy as np
 from pettingzoo.butterfly import pistonball_v4
-from supersuit import concat_vec_envs_v0, pettingzoo_env_to_vec_env_v0
+from supersuit import concat_vec_envs_v1, pettingzoo_env_to_vec_env_v1
 
 
 def make_env():
     env = pistonball_v4.parallel_env()
-    env = pettingzoo_env_to_vec_env_v0(env)
+    env = pettingzoo_env_to_vec_env_v1(env)
     return env
 
 # unfortunately this test does not pass
 # def test_vector_render_multiproc():
 #     env = make_env()
 #     num_envs = 3
-#     venv = concat_vec_envs_v0(env, num_envs, num_cpus=num_envs, base_class='stable_baselines3')
+#     venv = concat_vec_envs_v1(env, num_envs, num_cpus=num_envs, base_class='stable_baselines3')
 #     venv.reset()
 #     arr = venv.render(mode="rgb_array")
 #     venv.reset()


### PR DESCRIPTION
14 characters that can potentially mess up any SB3 experiments. Basically what happens is that these two wrappers (pettingzoo_env_to_vec_env_v0 and concat_vec_envs_v0) maintain an internal observation buffer that gets updated in-place. It's also returned by reference, which gets in the way in SB3. There, in one place of the code, they keep a `self._last_obs` variable which should remain the same after the following environment step is performed, but it gets updated because it points to said buffer.

The effect of this was that observations in evaluation were staggered by one with respect to the actions etc, so evaluation was performed on `(obs_{n+1}, action_{n}` tuples instead of `(obs_{n}, action_{n})`. This is obviously not ideal.

The fix here feels a bit like a hack, but I think it actually makes sense if the buffers are to be left in the code - it simply makes a copy of those values, so it's independent of any mutable state within the environment wrappers.