### PR TITLE
Rename from_parallel and to_parallel as per change in pettingzoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ So you can for example train 8 copies of pettingzoo's pistonball environment in 
 
 ```
 from stable_baselines3 import PPO
-from pettingzoo.butterfly import pistonball_v5
+from pettingzoo.butterfly import pistonball_v6
 import supersuit as ss
-env = pistonball_v5.parallel_env()
+env = pistonball_v6.parallel_env()
 env = ss.color_reduction_v0(env, mode='B')
 env = ss.resize_v0(env, x_size=84, y_size=84)
 env = ss.frame_stack_v1(env, 3)

--- a/supersuit/utils/wrapper_chooser.py
+++ b/supersuit/utils/wrapper_chooser.py
@@ -1,6 +1,6 @@
 import gym
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.conversions import to_parallel, from_parallel
+from pettingzoo.utils.conversions import aec_to_parallel, parallel_to_aec
 
 
 class WrapperChooser:
@@ -19,11 +19,11 @@ class WrapperChooser:
             if self.aec_wrapper is not None:
                 return self.aec_wrapper(env, *args, **kwargs)
             else:
-                return from_parallel(self.parallel_wrapper(to_parallel(env), *args, **kwargs))
+                return parallel_to_aec(self.parallel_wrapper(aec_to_parallel(env), *args, **kwargs))
         elif isinstance(env, ParallelEnv):
             if self.parallel_wrapper is not None:
                 return self.parallel_wrapper(env, *args, **kwargs)
             else:
-                return to_parallel(self.aec_wrapper(from_parallel(env), *args, **kwargs))
+                return aec_to_parallel(self.aec_wrapper(parallel_to_aec(env), *args, **kwargs))
         else:
             raise ValueError("environment passed to supersuit wrapper must either be a gym environment or a pettingzoo environment")

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -61,6 +61,6 @@ def concat_vec_envs_v1(vec_env, num_vec_envs, num_cpus=0, base_class='gym'):
 
 
 def pettingzoo_env_to_vec_env_v1(parallel_env):
-    assert isinstance(parallel_env, ParallelEnv), "pettingzoo_env_to_vec_env takes in a pettingzoo ParallelEnv. Can create a parallel_env with pistonball.parallel_env() or convert it from an AEC env with `from pettingzoo.utils.conversions import to_parallel; to_parallel(env)``"
+    assert isinstance(parallel_env, ParallelEnv), "pettingzoo_env_to_vec_env takes in a pettingzoo ParallelEnv. Can create a parallel_env with pistonball.parallel_env() or convert it from an AEC env with `from pettingzoo.utils.conversions import aec_to_parallel; aec_to_parallel(env)``"
     assert hasattr(parallel_env, 'possible_agents'), "environment passed to pettingzoo_env_to_vec_env must have possible_agents attribute."
     return MarkovVectorEnv(parallel_env)

--- a/test/pettingzoo_api_test.py
+++ b/test/pettingzoo_api_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pettingzoo.test import api_test, seed_test, parallel_test
 from pettingzoo.mpe import simple_push_v2, simple_world_comm_v2
-from pettingzoo.butterfly import knights_archers_zombies_v7, prison_v3
+from pettingzoo.butterfly import knights_archers_zombies_v8, prison_v3
 from pettingzoo.classic import chess_v5
 from pettingzoo.magent import combined_arms_v5
 
@@ -48,32 +48,32 @@ def test_pettingzoo_parallel_env():
 
 
 wrappers = [
-    supersuit.color_reduction_v0(knights_archers_zombies_v7.env(), "R"),
-    supersuit.resize_v0(dtype_v0(knights_archers_zombies_v7.env(), np.uint8), x_size=5, y_size=10),
-    supersuit.resize_v0(dtype_v0(knights_archers_zombies_v7.env(), np.uint8), x_size=5, y_size=10, linear_interp=True),
-    supersuit.dtype_v0(knights_archers_zombies_v7.env(), np.int32),
-    supersuit.flatten_v0(knights_archers_zombies_v7.env()),
-    supersuit.reshape_v0(knights_archers_zombies_v7.env(), (512 * 512, 3)),
-    supersuit.normalize_obs_v0(dtype_v0(knights_archers_zombies_v7.env(), np.float32), env_min=-1, env_max=5.0),
+    supersuit.color_reduction_v0(knights_archers_zombies_v8.env(), "R"),
+    supersuit.resize_v0(dtype_v0(knights_archers_zombies_v8.env(), np.uint8), x_size=5, y_size=10),
+    supersuit.resize_v0(dtype_v0(knights_archers_zombies_v8.env(), np.uint8), x_size=5, y_size=10, linear_interp=True),
+    supersuit.dtype_v0(knights_archers_zombies_v8.env(), np.int32),
+    supersuit.flatten_v0(knights_archers_zombies_v8.env()),
+    supersuit.reshape_v0(knights_archers_zombies_v8.env(), (512 * 512, 3)),
+    supersuit.normalize_obs_v0(dtype_v0(knights_archers_zombies_v8.env(), np.float32), env_min=-1, env_max=5.0),
     supersuit.frame_stack_v1(combined_arms_v5.env(), 8),
     supersuit.pad_observations_v0(simple_world_comm_v2.env()),
     supersuit.pad_action_space_v0(simple_world_comm_v2.env()),
     supersuit.black_death_v2(combined_arms_v5.env()),
-    supersuit.agent_indicator_v0(knights_archers_zombies_v7.env(), True),
-    supersuit.agent_indicator_v0(knights_archers_zombies_v7.env(), False),
-    supersuit.reward_lambda_v0(knights_archers_zombies_v7.env(), lambda x: x / 10),
+    supersuit.agent_indicator_v0(knights_archers_zombies_v8.env(), True),
+    supersuit.agent_indicator_v0(knights_archers_zombies_v8.env(), False),
+    supersuit.reward_lambda_v0(knights_archers_zombies_v8.env(), lambda x: x / 10),
     supersuit.clip_reward_v0(combined_arms_v5.env()),
     supersuit.clip_actions_v0(prison_v3.env(continuous=True)),
     supersuit.scale_actions_v0(prison_v3.env(continuous=True), 0.5),
-    supersuit.nan_noop_v0(knights_archers_zombies_v7.env(), 0),
-    supersuit.nan_zeros_v0(knights_archers_zombies_v7.env()),
+    supersuit.nan_noop_v0(knights_archers_zombies_v8.env(), 0),
+    supersuit.nan_zeros_v0(knights_archers_zombies_v8.env()),
     supersuit.nan_zeros_v0(prison_v3.env(continuous=True)),
     supersuit.nan_random_v0(chess_v5.env()),
-    supersuit.nan_random_v0(knights_archers_zombies_v7.env()),
+    supersuit.nan_random_v0(knights_archers_zombies_v8.env()),
     supersuit.frame_skip_v0(combined_arms_v5.env(), 4),
     supersuit.sticky_actions_v0(combined_arms_v5.env(), 0.75),
     supersuit.delay_observations_v0(combined_arms_v5.env(), 3),
-    supersuit.max_observation_v0(knights_archers_zombies_v7.env(), 3),
+    supersuit.max_observation_v0(knights_archers_zombies_v8.env(), 3),
 ]
 
 
@@ -89,7 +89,7 @@ parallel_wrappers = [
     supersuit.delay_observations_v0(combined_arms_v5.parallel_env(), 3),
     supersuit.delay_observations_v0(simple_push_v2.parallel_env(), 3),
     supersuit.dtype_v0(combined_arms_v5.parallel_env(), np.int32),
-    supersuit.color_reduction_v0(knights_archers_zombies_v7.parallel_env(), "R"),
+    supersuit.color_reduction_v0(knights_archers_zombies_v8.parallel_env(), "R"),
     supersuit.frame_skip_v0(combined_arms_v5.parallel_env(), 4),
     supersuit.frame_skip_v0(simple_push_v2.parallel_env(), 4),
     supersuit.max_observation_v0(combined_arms_v5.parallel_env(), 4),

--- a/test/test_vector/test_aec_vector_identity_env.py
+++ b/test/test_vector/test_aec_vector_identity_env.py
@@ -1,4 +1,4 @@
-from pettingzoo.butterfly import knights_archers_zombies_v7
+from pettingzoo.butterfly import knights_archers_zombies_v8
 from pettingzoo.mpe import simple_push_v2
 from supersuit import frame_skip_v0, vectorize_aec_env_v0
 import numpy as np
@@ -12,12 +12,12 @@ def recursive_equal(info1, info2):
 
 def test_identical():
     def env_fn():
-        return knights_archers_zombies_v7.env()  # ,20)
+        return knights_archers_zombies_v8.env()  # ,20)
 
     n_envs = 2
     # single threaded
-    env1 = vectorize_aec_env_v0(knights_archers_zombies_v7.env(), n_envs)
-    env2 = vectorize_aec_env_v0(knights_archers_zombies_v7.env(), n_envs, num_cpus=1)
+    env1 = vectorize_aec_env_v0(knights_archers_zombies_v8.env(), n_envs)
+    env2 = vectorize_aec_env_v0(knights_archers_zombies_v8.env(), n_envs, num_cpus=1)
     env1.seed(42)
     env2.seed(42)
     env1.reset()

--- a/test/test_vector/test_aec_vector_values.py
+++ b/test/test_vector/test_aec_vector_values.py
@@ -1,7 +1,7 @@
 from supersuit import vectorize_aec_env_v0
 from pettingzoo.classic import rps_v2
 from pettingzoo.classic import mahjong_v4, hanabi_v4
-from pettingzoo.butterfly import knights_archers_zombies_v7
+from pettingzoo.butterfly import knights_archers_zombies_v8
 from pettingzoo.mpe import simple_world_comm_v2
 import numpy as np
 import random
@@ -66,5 +66,5 @@ def test_all():
         test_vec_env(vectorize_aec_env_v0(mahjong_maker(), NUM_ENVS, num_cpus=num_cpus))
         test_infos(vectorize_aec_env_v0(hanabi_maker(), NUM_ENVS, num_cpus=num_cpus))
         test_some_done(vectorize_aec_env_v0(mahjong_maker(), NUM_ENVS, num_cpus=num_cpus))
-        test_vec_env(vectorize_aec_env_v0(knights_archers_zombies_v7.env(), NUM_ENVS, num_cpus=num_cpus))
+        test_vec_env(vectorize_aec_env_v0(knights_archers_zombies_v8.env(), NUM_ENVS, num_cpus=num_cpus))
         test_vec_env(vectorize_aec_env_v0(simple_world_comm_v2.env(), NUM_ENVS, num_cpus=num_cpus))

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -1,7 +1,7 @@
 import copy
 
 from pettingzoo.mpe import simple_spread_v2, simple_world_comm_v2
-from pettingzoo.butterfly import knights_archers_zombies_v7
+from pettingzoo.butterfly import knights_archers_zombies_v8
 from supersuit import pettingzoo_env_to_vec_env_v1, black_death_v2, concat_vec_envs_v1
 import pytest
 
@@ -64,7 +64,7 @@ def test_bad_action_spaces_env():
 
 
 def test_env_black_death_assertion():
-    env = knights_archers_zombies_v7.parallel_env(spawn_rate=50, max_cycles=2000)
+    env = knights_archers_zombies_v8.parallel_env(spawn_rate=50, max_cycles=2000)
     env = pettingzoo_env_to_vec_env_v1(env)
     with pytest.raises(AssertionError):
         for i in range(100):
@@ -75,7 +75,7 @@ def test_env_black_death_assertion():
 
 
 def test_env_black_death_wrapper():
-    env = knights_archers_zombies_v7.parallel_env(spawn_rate=50, max_cycles=300)
+    env = knights_archers_zombies_v8.parallel_env(spawn_rate=50, max_cycles=300)
     env = black_death_v2(env)
     env = pettingzoo_env_to_vec_env_v1(env)
     env.reset()

--- a/test/test_vector/test_render.py
+++ b/test/test_vector/test_render.py
@@ -1,12 +1,12 @@
 from supersuit import gym_vec_env_v0
 import gym
 import numpy as np
-from pettingzoo.butterfly import pistonball_v5
+from pettingzoo.butterfly import pistonball_v6
 from supersuit import concat_vec_envs_v1, pettingzoo_env_to_vec_env_v1
 
 
 def make_env():
-    env = pistonball_v5.parallel_env()
+    env = pistonball_v6.parallel_env()
     env = pettingzoo_env_to_vec_env_v1(env)
     return env
 

--- a/test/test_vector/test_vector_dict.py
+++ b/test/test_vector/test_vector_dict.py
@@ -2,7 +2,7 @@ from ..dummy_aec_env import DummyEnv
 from gym.spaces import Box, Discrete, Dict, Tuple
 from gym.vector.utils import concatenate, create_empty_array
 import numpy as np
-from pettingzoo.utils.conversions import to_parallel
+from pettingzoo.utils.conversions import aec_to_parallel
 from supersuit import pettingzoo_env_to_vec_env_v1, concat_vec_envs_v1
 
 n_agents = 5
@@ -37,7 +37,7 @@ def make_env():
         },
     )
     test_env.metadata["is_parallelizable"] = True
-    return to_parallel(test_env)
+    return aec_to_parallel(test_env)
 
 
 def dict_vec_env_test(env):


### PR DESCRIPTION
This implements a rename fix as per [the change made in PettingZoo](https://github.com/Farama-Foundation/PettingZoo/pull/604). Tests are expected to fail until the pull from PettingZoo side is made.