### PR TITLE
Possibly fix an issue with black_death

### DIFF
--- a/supersuit/multiagent_wrappers/black_death.py
+++ b/supersuit/multiagent_wrappers/black_death.py
@@ -26,7 +26,7 @@ class black_death_aec(ObservationWrapper):
         return Box(low=np.minimum(0, old_obs_space.low), high=np.maximum(0, old_obs_space.high), dtype=old_obs_space.dtype)
 
     def observe(self, agent):
-        return np.zeros_like(self.observation_space(agent).low) if agent not in self.env.dones else self.env.observe(agent)
+        return np.zeros_like(self.observation_space(agent).low) if self.env.dones[agent] else self.env.observe(agent)
 
     def reset(self):
         super().reset()


### PR DESCRIPTION
I'm putting this here to possibly get some eyes on this in the meantime. Maybe I'm missing something obvious, but maybe I'm not. The tl;dr is that I think `black_death_v2` might be fundamentally broken, and this is a proposed fix.

The only rough edge I can see around my analysis is what exactly `env.dones` is supposed to be -- particularly if it should contain all agents, or only agents that have been active in the last step or something like that. Which I guess is part of the API description? But idk if it's actually standarized anywhere.

If the API is that `env.dones` is supposed to have a key for every agent that has ever existed (or I guess will ever exist; [this seems to be the case in KAZ at least](https://github.com/Farama-Foundation/PettingZoo/blob/master/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py#L371)), then I'm like 99% sure the rest of this message is correct, and that the wrapper is broken. The 1% is that it's 2AM at the time of writing.

Obviously this will call for a version bump, so don't merge it yet.

-----
(pasting a message from Discord with a larger explanation because I'm lazy)


I'm running the following code:
```python
obs = env.reset()
for i in trange(1000):
    obs, reward, done, info = env.step({agent_id: env.action_space(agent_id).sample() for agent_id in obs})

    if any(done.values()):
        print(i)
        obs = env.reset()
```

Basically just run a bunch of steps and reset whenever needed. The env is created with this, based on the code from the repo:
```python
def create_env():
    env = knights_archers_zombies_v8.parallel_env()

    env = ss.color_reduction_v0(env, mode="R")
    env = ss.resize_v0(env, x_size=84, y_size=84)
    env = ss.pad_action_space_v0(env)
    env = ss.frame_stack_v1(env, 3)
    env = ss.black_death_v2(env)
    return env
```

And this crashes once every few episodes.

The reason seems to be that one of the agents is actually dead, so the environment tries to get its observation - but there's no observation, so crash.

This should be handled by the black_death wrapper, and I tracked down a very suspicious line in its code (on master)
```python
def observe(self, agent):
    return np.zeros_like(self.observation_space(agent).low) if agent not in self.env.dones else self.env.observe(agent)
```

The idea of this is that if an agent is `done`, then just do zeros; otherwise, get the actual observation.

The problem is that `self.env.dones` is a dictionary that maps each agent to a boolean... and `thing in dict` checks if `thing` is a key in the dictionary. Doesn't matter what its value is. So if we map each agent to whether or not it's alive, this check will just ignore it and pretend all agents are alive. So then it will get the observation for the dead agent. And it will fail. 


It's one of the things where I'm hesitant to believe myself because I think it breaks the wrapper, like, completely? Unless different envs process the dones differently I guess.