### PR TITLE
removed unnecessary assert check

### DIFF
--- a/supersuit/vector/constructors.py
+++ b/supersuit/vector/constructors.py
@@ -32,7 +32,6 @@ def MakeCPUAsyncConstructor(max_num_cpus):
                 env_cpu_div.append(env_fn_list[start_idx:end_idx])
                 num_envs_alloced = end_idx
 
-            assert alloced_num_cpus == len(env_cpu_div)
 
             cat_env_fns = [call_wrap(ConcatVecEnv, env_fns) for env_fns in env_cpu_div]
             return ProcConcatVec(

--- a/supersuit/vector/constructors.py
+++ b/supersuit/vector/constructors.py
@@ -32,7 +32,6 @@ def MakeCPUAsyncConstructor(max_num_cpus):
                 env_cpu_div.append(env_fn_list[start_idx:end_idx])
                 num_envs_alloced = end_idx
 
-
             cat_env_fns = [call_wrap(ConcatVecEnv, env_fns) for env_fns in env_cpu_div]
             return ProcConcatVec(
                 cat_env_fns,


### PR DESCRIPTION
Specifically, helps with variable numbers of agents in the differnet constructors, something like this:
```
venv = MakeCPUAsyncConstructor(3)([make_env_fn(n_walkers=2), make_env_fn(n_walkers=3), make_env_fn(n_walkers=7), ], observation_space=example_env.observation_space(example_env.possible_agents[0]), action_space=example_env.action_space(example_env.possible_agents[0]),tot_num_envs=2+3+7,metadata={})
```