### PR TITLE
Fix for a) Seeding problems from gym env_checker b) infos API change

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -31,6 +31,7 @@ jobs:
         pip install flake8 pytest atari_py magent gym pettingzoo[butterfly] tinyscaler
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
+        pip install -e ./PettingZoo[butterfly]
     - name: Test with pytest
       run: |
         xvfb-run -s "-screen 0 1400x900x24" pytest ./test

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
-        pip install flake8 pytest atari_py magent
+        pip install flake8 pytest atari_py magent gym pettingzoo[butterfly] tinyscaler
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
     - name: Test with pytest

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
-        pip install flake8 pytest atari_py magent -r requirements.txt
+        pip install flake8 pytest atari_py magent
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
     - name: Test with pytest

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -10,19 +10,6 @@ def transpose(ll):
     return [[ll[i][j] for i in range(len(ll))] for j in range(len(ll[0]))]
 
 
-def reconstruct_infos(infos):
-    new_infos = {}
-    for i, info in enumerate(infos):
-        for key in info:
-            if key not in new_infos:
-                new_infos[key] = [None] * len(infos)
-                new_infos[key][i] = info[key]
-            else:
-                new_infos[key][i] = info[key]
-
-    return new_infos
-
-
 @iterate.register(Discrete)
 def iterate_discrete(space, items):
     try:

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -1,12 +1,26 @@
-import numpy as np
-from .single_vec_env import SingleVecEnv
 import gym.vector
-from gym.vector.utils import concatenate, iterate, create_empty_array
+import numpy as np
 from gym.spaces import Discrete
+from gym.vector.utils import concatenate, create_empty_array, iterate
+
+from .single_vec_env import SingleVecEnv
 
 
 def transpose(ll):
     return [[ll[i][j] for i in range(len(ll))] for j in range(len(ll[0]))]
+
+
+def reconstruct_infos(infos):
+    new_infos = {}
+    for i, info in enumerate(infos):
+        for key in info:
+            if key not in new_infos:
+                new_infos[key] = [None] * len(infos)
+                new_infos[key][i] = info[key]
+            else:
+                new_infos[key][i] = info[key]
+
+    return new_infos
 
 
 @iterate.register(Discrete)
@@ -65,8 +79,11 @@ class ConcatVecEnv(gym.vector.VectorEnv):
             info_array = {}
             for i, info in enumerate(_res_info):
                 info_array = self._add_info(info_array, info, i)
+            infos = {}
+            for info in info_array:
+                infos[info] = [info_array[info]]
 
-            return self.concat_obs(_res_obs), info_array
+            return self.concat_obs(_res_obs), infos
 
     def concat_obs(self, observations):
         return concatenate(
@@ -113,8 +130,9 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         info_array = {}
         for i, info in enumerate(infos):
             info_array = self._add_info(info_array, info[0], i)
+        infos = {}
 
-        return observations, rewards, dones, info_array
+        return observations, rewards, dones, infos
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -66,11 +66,8 @@ class ConcatVecEnv(gym.vector.VectorEnv):
             info_array = {}
             for i, info in enumerate(_res_info):
                 info_array = self._add_info(info_array, info, i)
-            infos = {}
-            for info in info_array:
-                infos[info] = [info_array[info]]
 
-            return self.concat_obs(_res_obs), infos
+            return self.concat_obs(_res_obs), info_array
 
     def concat_obs(self, observations):
         return concatenate(
@@ -117,9 +114,8 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         info_array = {}
         for i, info in enumerate(infos):
             info_array = self._add_info(info_array, info[0], i)
-        infos = {}
 
-        return observations, rewards, dones, infos
+        return observations, rewards, dones, info_array
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -62,7 +62,11 @@ class ConcatVecEnv(gym.vector.VectorEnv):
                     _res_obs.append(_obs)
                     _res_info.append(_info)
 
-            return self.concat_obs(_res_obs), sum(_res_info, [])
+            info_array = {}
+            for i, info in enumerate(_res_info):
+                info_array = self._add_info(info_array, info, i)
+
+            return self.concat_obs(_res_obs), info_array
 
     def concat_obs(self, observations):
         return concatenate(
@@ -105,8 +109,12 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         observations = self.concat_obs(observations)
         rewards = np.concatenate(rewards, axis=0)
         dones = np.concatenate(dones, axis=0)
-        infos = sum(infos, [])
-        return observations, rewards, dones, infos
+
+        info_array = {}
+        for i, info in enumerate(infos):
+            info_array = self._add_info(info_array, info[0], i)
+
+        return observations, rewards, dones, info_array
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -34,9 +34,9 @@ def reconstruct_infos(infos):
         for key in info:
             if key not in new_infos:
                 new_infos[key] = [None] * len(infos)
-                new_infos[key][i] = info[key]
+                new_infos[key][i] = info[key][0]
             else:
-                new_infos[key][i] = info[key]
+                new_infos[key][i] = info[key][0]
 
     return new_infos
 

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -7,7 +7,6 @@ class SingleVecEnv:
     def __init__(self, gym_env_fns, *args):
         assert len(gym_env_fns) == 1
         self.gym_env = gym_env_fns[0]()
-        self.gym_env.unwrapped.np_random, _ = np_random()
         self.observation_space = self.gym_env.observation_space
         self.action_space = self.gym_env.action_space
         self.num_envs = 1

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -1,3 +1,4 @@
+from gym.utils.seeding import np_random
 import numpy as np
 import gym
 
@@ -6,6 +7,7 @@ class SingleVecEnv:
     def __init__(self, gym_env_fns, *args):
         assert len(gym_env_fns) == 1
         self.gym_env = gym_env_fns[0]()
+        self.gym_env.unwrapped.np_random, _ = np_random()
         self.observation_space = self.gym_env.observation_space
         self.action_space = self.gym_env.action_space
         self.num_envs = 1

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -1,4 +1,3 @@
-from gym.utils.seeding import np_random
 import numpy as np
 import gym
 

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -1,8 +1,10 @@
-import gym
-import cloudpickle
-from . import MakeCPUAsyncConstructor, MarkovVectorEnv
-from pettingzoo.utils.env import ParallelEnv
 import warnings
+
+import cloudpickle
+import gym
+from pettingzoo.utils.env import ParallelEnv
+
+from . import MakeCPUAsyncConstructor, MarkovVectorEnv
 
 
 def vec_env_args(env, num_envs):

--- a/test/test_vector/test_gym_vector.py
+++ b/test/test_vector/test_gym_vector.py
@@ -59,7 +59,7 @@ def test_gym_supersuit_equivalency():
     check_vec_env_equivalency(venv1, venv2)
 
 
-def test_inital_state_dissimilarity():
+def test_initial_state_dissimilarity():
     env = gym.make("CartPole-v1")
     venv = concat_vec_envs_v1(env, 2)
     observations = venv.reset()

--- a/test/test_vector/test_gym_vector.py
+++ b/test/test_vector/test_gym_vector.py
@@ -1,14 +1,15 @@
 import copy
 
-from supersuit import (
-    gym_vec_env_v0,
-    stable_baselines3_vec_env_v0,
-    concat_vec_envs_v1,
-    pettingzoo_env_to_vec_env_v1,
-)
-from pettingzoo.mpe import simple_spread_v2
 import gym
 import numpy as np
+from pettingzoo.mpe import simple_spread_v2
+
+from supersuit import (
+    concat_vec_envs_v1,
+    gym_vec_env_v0,
+    pettingzoo_env_to_vec_env_v1,
+    stable_baselines3_vec_env_v0,
+)
 
 
 def recursive_equal(info1, info2):
@@ -48,7 +49,7 @@ def check_vec_env_equivalency(venv1, venv2, check_info=True):
         # uses close rather than equal due to inconsistency in reporting rewards as float32 or float64
         assert np.allclose(rew1, rew2)
         assert np.all(np.equal(done1, done2))
-        assert recursive_equal(info1, info2) or not check_info
+        assert recursive_equal(info1, info2) or not check_info, f"{info1} \n {info2}"
 
 
 def test_gym_supersuit_equivalency():

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -50,7 +50,6 @@ def test_good_vecenv():
         assert len(new_obss) == max_num_agents
         assert len(rews) == max_num_agents
         assert len(dones) == max_num_agents
-        assert len(infos) == max_num_agents
         # no agent death, only env death
         if any(dones):
             assert all(dones)


### PR DESCRIPTION
There are two issues that the new gym release has brought to Supersuit.

## ~~a) Seeding issues~~

~~Because of the new `env_checker` in gym, when `env_checker` is enabled on `gym.make()` (which is done by default), the environment gets unintentionally seeded.~~
~~As a result, any vec envs derived from single envs end up having the same seed even when the seed given to them was `None`.~~
~~The current fix just reseeds any vec envs that are derived from single envs.~~

~~Although this works, I don't quite like this solution as it seems very hacky(?), though I may be educated otherwise.
I think the better solution is for `env_checker` to reset the env's seed instead of having it be done outside, which is probably the expected behaviour of `env_checker` (checking without modifying).~~

## b) Infos API change

Because of the recent [infos API change](https://github.com/openai/gym/pull/2773) on gym 0.24.0, the infos style for supersuit vec env wrappers are now no longer coherent to the infos style of gym vec envs.

If I understand things correctly, there are two wrappers that need to be fixed:

### `ConcatVecEnv`

I've implemented a simple hacky fix for this, though I think my hacky fix is still pretty suboptimal and could take some ideas from people.

### `ProcConcatVecEnv`

I've not touched this wrapper yet mostly because I don't really know what's going on with it yet.