### PR TITLE
Truncation Termination API Update for Lambda and Tests

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -31,6 +31,7 @@ jobs:
         pip install flake8 pytest atari_py magent gym pettingzoo[butterfly] tinyscaler
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
+        pip install -e ./PettingZoo[butterfly]
     - name: Test with pytest
       run: |
         xvfb-run -s "-screen 0 1400x900x24" pytest ./test

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
-        pip install flake8 pytest atari_py magent
+        pip install flake8 pytest atari_py magent gym pettingzoo[butterfly] tinyscaler
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
     - name: Test with pytest

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get install python-opengl xvfb
     - name: Install python dependencies
       run: |
-        pip install flake8 pytest atari_py magent -r requirements.txt
+        pip install flake8 pytest atari_py magent
         git clone https://github.com/Farama-Foundation/PettingZoo.git
         pip install -e ./PettingZoo[classic]
     - name: Test with pytest

--- a/supersuit/lambda_wrappers/observation_lambda.py
+++ b/supersuit/lambda_wrappers/observation_lambda.py
@@ -112,9 +112,9 @@ class gym_observation_lambda(gym.Wrapper):
         return self.change_observation_fn(observation, self.env.observation_space)
 
     def step(self, action):
-        observation, rew, done, info = self.env.step(action)
+        observation, rew, termination, truncation, info = self.env.step(action)
         observation = self._modify_observation(observation)
-        return observation, rew, done, info
+        return observation, rew, termination, truncation, info
 
     def reset(self, seed=None, return_info=False, options=None):
         if not return_info:

--- a/supersuit/lambda_wrappers/reward_lambda.py
+++ b/supersuit/lambda_wrappers/reward_lambda.py
@@ -50,8 +50,8 @@ class gym_reward_lambda(gym.Wrapper):
         super().__init__(env)
 
     def step(self, action):
-        obs, rew, done, info = super().step(action)
-        return obs, self._change_reward_fn(rew), done, info
+        obs, rew, termination, truncation, info = super().step(action)
+        return obs, self._change_reward_fn(rew), termination, truncation, info
 
 
 reward_lambda_v0 = WrapperChooser(

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -10,19 +10,6 @@ def transpose(ll):
     return [[ll[i][j] for i in range(len(ll))] for j in range(len(ll[0]))]
 
 
-def reconstruct_infos(infos):
-    new_infos = {}
-    for i, info in enumerate(infos):
-        for key in info:
-            if key not in new_infos:
-                new_infos[key] = [None] * len(infos)
-                new_infos[key][i] = info[key]
-            else:
-                new_infos[key][i] = info[key]
-
-    return new_infos
-
-
 @iterate.register(Discrete)
 def iterate_discrete(space, items):
     try:

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -1,12 +1,26 @@
-import numpy as np
-from .single_vec_env import SingleVecEnv
 import gym.vector
-from gym.vector.utils import concatenate, iterate, create_empty_array
+import numpy as np
 from gym.spaces import Discrete
+from gym.vector.utils import concatenate, create_empty_array, iterate
+
+from .single_vec_env import SingleVecEnv
 
 
 def transpose(ll):
     return [[ll[i][j] for i in range(len(ll))] for j in range(len(ll[0]))]
+
+
+def reconstruct_infos(infos):
+    new_infos = {}
+    for i, info in enumerate(infos):
+        for key in info:
+            if key not in new_infos:
+                new_infos[key] = [None] * len(infos)
+                new_infos[key][i] = info[key]
+            else:
+                new_infos[key][i] = info[key]
+
+    return new_infos
 
 
 @iterate.register(Discrete)
@@ -65,8 +79,11 @@ class ConcatVecEnv(gym.vector.VectorEnv):
             info_array = {}
             for i, info in enumerate(_res_info):
                 info_array = self._add_info(info_array, info, i)
+            infos = {}
+            for info in info_array:
+                infos[info] = [info_array[info]]
 
-            return self.concat_obs(_res_obs), info_array
+            return self.concat_obs(_res_obs), infos
 
     def concat_obs(self, observations):
         return concatenate(
@@ -113,8 +130,9 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         info_array = {}
         for i, info in enumerate(infos):
             info_array = self._add_info(info_array, info[0], i)
+        infos = {}
 
-        return observations, rewards, dones, info_array
+        return observations, rewards, dones, infos
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -66,11 +66,8 @@ class ConcatVecEnv(gym.vector.VectorEnv):
             info_array = {}
             for i, info in enumerate(_res_info):
                 info_array = self._add_info(info_array, info, i)
-            infos = {}
-            for info in info_array:
-                infos[info] = [info_array[info]]
 
-            return self.concat_obs(_res_obs), infos
+            return self.concat_obs(_res_obs), info_array
 
     def concat_obs(self, observations):
         return concatenate(
@@ -117,9 +114,8 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         info_array = {}
         for i, info in enumerate(infos):
             info_array = self._add_info(info_array, info[0], i)
-        infos = {}
 
-        return observations, rewards, dones, infos
+        return observations, rewards, dones, info_array
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -62,7 +62,11 @@ class ConcatVecEnv(gym.vector.VectorEnv):
                     _res_obs.append(_obs)
                     _res_info.append(_info)
 
-            return self.concat_obs(_res_obs), sum(_res_info, [])
+            info_array = {}
+            for i, info in enumerate(_res_info):
+                info_array = self._add_info(info_array, info, i)
+
+            return self.concat_obs(_res_obs), info_array
 
     def concat_obs(self, observations):
         return concatenate(
@@ -105,8 +109,12 @@ class ConcatVecEnv(gym.vector.VectorEnv):
         observations = self.concat_obs(observations)
         rewards = np.concatenate(rewards, axis=0)
         dones = np.concatenate(dones, axis=0)
-        infos = sum(infos, [])
-        return observations, rewards, dones, infos
+
+        info_array = {}
+        for i, info in enumerate(infos):
+            info_array = self._add_info(info_array, info[0], i)
+
+        return observations, rewards, dones, info_array
 
     def render(self, mode="human"):
         return self.vec_envs[0].render(mode)

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -34,9 +34,9 @@ def reconstruct_infos(infos):
         for key in info:
             if key not in new_infos:
                 new_infos[key] = [None] * len(infos)
-                new_infos[key][i] = info[key]
+                new_infos[key][i] = info[key][0]
             else:
-                new_infos[key][i] = info[key]
+                new_infos[key][i] = info[key][0]
 
     return new_infos
 

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -7,7 +7,6 @@ class SingleVecEnv:
     def __init__(self, gym_env_fns, *args):
         assert len(gym_env_fns) == 1
         self.gym_env = gym_env_fns[0]()
-        self.gym_env.unwrapped.np_random, _ = np_random()
         self.observation_space = self.gym_env.observation_space
         self.action_space = self.gym_env.action_space
         self.num_envs = 1

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -1,3 +1,4 @@
+from gym.utils.seeding import np_random
 import numpy as np
 import gym
 
@@ -6,6 +7,7 @@ class SingleVecEnv:
     def __init__(self, gym_env_fns, *args):
         assert len(gym_env_fns) == 1
         self.gym_env = gym_env_fns[0]()
+        self.gym_env.unwrapped.np_random, _ = np_random()
         self.observation_space = self.gym_env.observation_space
         self.action_space = self.gym_env.action_space
         self.num_envs = 1

--- a/supersuit/vector/single_vec_env.py
+++ b/supersuit/vector/single_vec_env.py
@@ -1,4 +1,3 @@
-from gym.utils.seeding import np_random
 import numpy as np
 import gym
 

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -1,8 +1,10 @@
-import gym
-import cloudpickle
-from . import MakeCPUAsyncConstructor, MarkovVectorEnv
-from pettingzoo.utils.env import ParallelEnv
 import warnings
+
+import cloudpickle
+import gym
+from pettingzoo.utils.env import ParallelEnv
+
+from . import MakeCPUAsyncConstructor, MarkovVectorEnv
 
 
 def vec_env_args(env, num_envs):

--- a/test/aec_mock_test.py
+++ b/test/aec_mock_test.py
@@ -105,8 +105,8 @@ def test_frame_skip():
     env = supersuit.frame_skip_v0(base_env, 3)
     env.reset()
     for a in env.agent_iter(8):
-        obs, rew, done, info = env.last()
-        env.step(0 if not done else None)
+        obs, rew, termination, truncation, info = env.last()
+        env.step(0 if not termination or not truncation else None)
 
 
 def test_agent_indicator():
@@ -229,7 +229,11 @@ def test_basic_wrappers(env):
     env.step(act_space.sample())
     for agent in env.agent_iter():
         act_space = env.action_space(env.agent_selection)
-        env.step(act_space.sample() if not env.dones[agent] else None)
+        env.step(
+            act_space.sample()
+            if not env.terminations[agent] or not env.truncations[agent]
+            else None
+        )
 
 
 def test_rew_lambda():

--- a/test/dummy_aec_env.py
+++ b/test/dummy_aec_env.py
@@ -29,16 +29,19 @@ class DummyEnv(AECEnv):
         return self._observations[agent]
 
     def step(self, action, observe=True):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            return self._was_dead_step(action)
         self._cumulative_rewards[self.agent_selection] = 0
         self.agent_selection = self._agent_selector.next()
         self.steps += 1
         if self.steps >= 5 * len(self.agents):
-            self.dones = {a: True for a in self.agents}
+            self.truncations = {a: True for a in self.agents}
 
         self._accumulate_rewards()
-        self._dones_step_first()
+        self._deads_step_first()
 
     def reset(self, seed=None, return_info=False, options=None):
         self.agents = self.possible_agents[:]
@@ -46,7 +49,8 @@ class DummyEnv(AECEnv):
         self.agent_selection = self._agent_selector.reset()
         self.rewards = {a: 1 for a in self.agents}
         self._cumulative_rewards = {a: 0 for a in self.agents}
-        self.dones = {a: False for a in self.agents}
+        self.terminations = {a: False for a in self.agents}
+        self.truncations = {a: False for a in self.agents}
         self.infos = {a: {} for a in self.agents}
         self.steps = 0
 

--- a/test/dummy_gym_env.py
+++ b/test/dummy_gym_env.py
@@ -10,7 +10,7 @@ class DummyEnv(gym.Env):
         self.action_space = action_space
 
     def step(self, action):
-        return self._observation, 1, False, {}
+        return self._observation, 1, False, False, {}
 
     def reset(self, seed=None, return_info=False, options=None):
         if not return_info:

--- a/test/gym_mock_test.py
+++ b/test/gym_mock_test.py
@@ -135,5 +135,5 @@ def test_action_lambda():
 def test_rew_lambda():
     env = supersuit.reward_lambda_v0(new_dummy(), lambda x: x / 10)
     env.reset()
-    obs, rew, done, info = env.step(0)
+    obs, rew, termination, truncation, info = env.step(0)
     assert rew == 1.0 / 10

--- a/test/parallel_env_test.py
+++ b/test/parallel_env_test.py
@@ -18,7 +18,8 @@ class DummyParEnv(ParallelEnv):
         self._action_spaces = action_spaces
 
         self.rewards = {a: 1 for a in self.agents}
-        self.dones = {a: False for a in self.agents}
+        self.terminations = {a: False for a in self.agents}
+        self.truncations = {a: False for a in self.agents}
         self.infos = {a: {} for a in self.agents}
 
     def observation_space(self, agent):
@@ -30,7 +31,13 @@ class DummyParEnv(ParallelEnv):
     def step(self, actions):
         for agent, action in actions.items():
             assert action in self.action_space(agent)
-        return self._observations, self.rewards, self.dones, self.infos
+        return (
+            self._observations,
+            self.rewards,
+            self.terminations,
+            self.truncations,
+            self.infos,
+        )
 
     def reset(self, seed=None, return_info=False, options=None):
         if not return_info:
@@ -60,4 +67,4 @@ def test_basic():
     orig_obs = env.reset()
     for i in range(10):
         action = {agent: env.action_space(agent).sample() for agent in env.agents}
-        obs, rew, done, info = env.step(action)
+        obs, rew, termination, truncation, info = env.step(action)

--- a/test/test_vector/test_gym_vector.py
+++ b/test/test_vector/test_gym_vector.py
@@ -59,7 +59,7 @@ def test_gym_supersuit_equivalency():
     check_vec_env_equivalency(venv1, venv2)
 
 
-def test_inital_state_dissimilarity():
+def test_initial_state_dissimilarity():
     env = gym.make("CartPole-v1")
     venv = concat_vec_envs_v1(env, 2)
     observations = venv.reset()

--- a/test/test_vector/test_gym_vector.py
+++ b/test/test_vector/test_gym_vector.py
@@ -1,14 +1,15 @@
 import copy
 
-from supersuit import (
-    gym_vec_env_v0,
-    stable_baselines3_vec_env_v0,
-    concat_vec_envs_v1,
-    pettingzoo_env_to_vec_env_v1,
-)
-from pettingzoo.mpe import simple_spread_v2
 import gym
 import numpy as np
+from pettingzoo.mpe import simple_spread_v2
+
+from supersuit import (
+    concat_vec_envs_v1,
+    gym_vec_env_v0,
+    pettingzoo_env_to_vec_env_v1,
+    stable_baselines3_vec_env_v0,
+)
 
 
 def recursive_equal(info1, info2):
@@ -48,7 +49,7 @@ def check_vec_env_equivalency(venv1, venv2, check_info=True):
         # uses close rather than equal due to inconsistency in reporting rewards as float32 or float64
         assert np.allclose(rew1, rew2)
         assert np.all(np.equal(done1, done2))
-        assert recursive_equal(info1, info2) or not check_info
+        assert recursive_equal(info1, info2) or not check_info, f"{info1} \n {info2}"
 
 
 def test_gym_supersuit_equivalency():

--- a/test/test_vector/test_pettingzoo_to_vec.py
+++ b/test/test_vector/test_pettingzoo_to_vec.py
@@ -50,7 +50,6 @@ def test_good_vecenv():
         assert len(new_obss) == max_num_agents
         assert len(rews) == max_num_agents
         assert len(dones) == max_num_agents
-        assert len(infos) == max_num_agents
         # no agent death, only env death
         if any(dones):
             assert all(dones)

--- a/test/vec_env_test.py
+++ b/test/vec_env_test.py
@@ -8,7 +8,9 @@ def test_vec_env_args():
     num_envs = 8
     vec_env = gym_vec_env_v0(env, num_envs)
     vec_env.reset()
-    obs, rew, dones, infos = vec_env.step([0] + [1] * (vec_env.num_envs - 1))
+    obs, rew, terminations, truncations, infos = vec_env.step(
+        [0] + [1] * (vec_env.num_envs - 1)
+    )
     assert not np.any(np.equal(obs[0], obs[1]))
 
 


### PR DESCRIPTION
This updates the lambda wrappers to the latest truncation termination API, and updates a bunch of the tests too.

AFAIK, this PR is done, as `test_vector` and `test_utils` files requies `aec_wrappers` and `utils` to be updated in a separate PR.

Tests for this PR _will not pass_ because of #165.