### PR TITLE
fix: np.equal in test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=["Reinforcement Learning", "game", "RL", "AI", "gymnasium"],
     python_requires=">=3.7, <3.11",
     packages=find_packages(),
-    install_requires=["numpy>=1.18.0", "gymnasium>=0.26.0"],
+    install_requires=["numpy>=1.19.0", "gymnasium>=0.26.0"],
     extras={"dev": ["pettingzoo[butterfly]"]},
     classifiers=[
         "Programming Language :: Python :: 3.10",

--- a/test/aec_mock_test.py
+++ b/test/aec_mock_test.py
@@ -45,7 +45,7 @@ def test_frame_stack():
     assert obs.shape == (2, 3, 4)
     env.step(2)
     first_obs, _, _, _, _ = env.last()
-    assert np.all(np.equal(first_obs[:, :, -1], base_obs["a1"], dtype=np.float32))
+    assert np.array_equal(first_obs[:, :, -1], base_obs["a1"])
 
     base_obs = {"a{}".format(idx): idx + 3 for idx in range(2)}
     base_env = DummyEnv(base_obs, base_act_spaces, base_act_spaces)
@@ -80,7 +80,7 @@ def test_frame_stack():
     assert obs.shape == (2, 3, 4)
     env.step(2)
     first_obs, _, _, _, _ = env.last()
-    assert np.all(np.equal(first_obs[:, :, -1], base_obs["a1"], dtype=np.float32))
+    assert np.array_equal(first_obs[:, :, -1], base_obs["a1"])
 
     base_obs = {"a{}".format(idx): idx + 3 for idx in range(2)}
     base_env = DummyEnv(base_obs, base_act_spaces, base_act_spaces)


### PR DESCRIPTION
Using `np.equal` in tests gives `TypeError: No loop matching the specified signature and casting was found for ufunc equal` with numpy 1.24.
This changes it with `np.array_equal` instead.