### PR TITLE
Fix typo: `BaseParallelWraper` renamed to `BaseParallelWrapper`

### DIFF
--- a/supersuit/generic_wrappers/frame_skip.py
+++ b/supersuit/generic_wrappers/frame_skip.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from supersuit.utils.frame_skip import check_transform_frameskip
 from supersuit.utils.wrapper_chooser import WrapperChooser
-from pettingzoo.utils.wrappers import BaseWrapper, BaseParallelWraper
+from pettingzoo.utils.wrappers import BaseWrapper, BaseParallelWrapper
 import gymnasium
 from supersuit.utils.make_defaultdict import make_defaultdict
 
@@ -119,7 +119,7 @@ class frame_skip_aec(StepAltWrapper):
         self._deads_step_first()
 
 
-class frame_skip_par(BaseParallelWraper):
+class frame_skip_par(BaseParallelWrapper):
     def __init__(self, env, num_frames, default_action=None):
         super().__init__(env)
         self.num_frames = check_transform_frameskip(num_frames)

--- a/supersuit/generic_wrappers/utils/shared_wrapper_util.py
+++ b/supersuit/generic_wrappers/utils/shared_wrapper_util.py
@@ -2,7 +2,7 @@ import functools
 import gymnasium
 from pettingzoo.utils.wrappers import OrderEnforcingWrapper as PettingzooWrap
 from supersuit.utils.wrapper_chooser import WrapperChooser
-from pettingzoo.utils import BaseParallelWraper
+from pettingzoo.utils import BaseParallelWrapper
 
 
 class shared_wrapper_aec(PettingzooWrap):
@@ -68,7 +68,7 @@ class shared_wrapper_aec(PettingzooWrap):
         return self.modifiers[agent].get_last_obs()
 
 
-class shared_wrapper_parr(BaseParallelWraper):
+class shared_wrapper_parr(BaseParallelWrapper):
     def __init__(self, env, modifier_class):
         super().__init__(env)
 

--- a/supersuit/multiagent_wrappers/black_death.py
+++ b/supersuit/multiagent_wrappers/black_death.py
@@ -1,10 +1,10 @@
-from pettingzoo.utils.wrappers import BaseParallelWraper
+from pettingzoo.utils.wrappers import BaseParallelWrapper
 import numpy as np
 import gymnasium
 from supersuit.utils.wrapper_chooser import WrapperChooser
 
 
-class black_death_par(BaseParallelWraper):
+class black_death_par(BaseParallelWrapper):
     def __init__(self, env):
         super().__init__(env)
 


### PR DESCRIPTION
# Description
As title, fix typo of `BaseParallelWrapper` (previously `BaseParallelWraper`). Linked to its PettingZoo counterpart https://github.com/Farama-Foundation/PettingZoo/pull/876.