### PR TITLE
Update sb3_vector_wrapper to fix compatibility issues

### DIFF
--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -14,7 +14,9 @@ class SB3VecEnvWrapper(VecEnvWrapper):
         return self.venv.reset()
 
     def step_wait(self):
-        return self.venv.step_wait()
+        obss, rews, terms, truncs, infos = self.venv.step_wait()
+        dones = truncs | terms
+        return obss, rews, dones, infos
 
     def env_is_wrapped(self, wrapper_class, indices=None):
         # ignores indicies


### PR DESCRIPTION
Fix: change step_wait() in SB3VecEnvWrapper to return `dones` rather than `terminations` and `truncations`, as SB3 internally uses `dones` rather than gymnasium/pettingzoo's `terminations` and `truncations`. 

See https://github.com/DLR-RM/stable-baselines3/pull/1327
and https://github.com/DLR-RM/stable-baselines3/issues/1356