### PR TITLE
Fix SB3VecEnvWrapper and ProcConcatVec to work with SB3 v2.0.0

### DIFF
--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -118,10 +118,6 @@ class ProcConcatVec(gymnasium.vector.VectorEnv):
     def __init__(
         self, vec_env_constrs, observation_space, action_space, tot_num_envs, metadata
     ):
-        raise NotImplementedError(
-            "The wrapper ProcConcatVec is temporarily depreciated whilst it is being debugged. "
-            "Please refer to https://github.com/Farama-Foundation/SuperSuit/pull/165 for more information, or to contact the devs in regard to this."
-        )
         self.observation_space = observation_space
         self.action_space = action_space
         self.num_envs = num_envs = tot_num_envs

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -1,4 +1,8 @@
+from typing import Any, List
+
+import numpy as np
 from stable_baselines3.common.vec_env import VecEnvWrapper
+from stable_baselines3.common.vec_env.base_vec_env import VecEnvIndices
 
 
 class SB3VecEnvWrapper(VecEnvWrapper):
@@ -7,6 +11,7 @@ class SB3VecEnvWrapper(VecEnvWrapper):
         self.num_envs = venv.num_envs
         self.observation_space = venv.observation_space
         self.action_space = venv.action_space
+        # self.render_mode = venv.render_mode
 
     def reset(self, seed=None, options=None):
         if seed is not None:
@@ -14,7 +19,13 @@ class SB3VecEnvWrapper(VecEnvWrapper):
         return self.venv.reset()
 
     def step_wait(self):
-        return self.venv.step_wait()
+        observations, rewards, terminations, truncations, infos = self.venv.step_wait()
+
+        # Note: SB3 expects dones to be an np array (TODO: they should fix this, and cast the dones to an array)
+        dones = np.array(
+            [terminations[i] or truncations[i] for i in range(len(terminations))]
+        )
+        return observations, rewards, dones, infos
 
     def env_is_wrapped(self, wrapper_class, indices=None):
         # ignores indices
@@ -25,3 +36,11 @@ class SB3VecEnvWrapper(VecEnvWrapper):
 
     def getattr_depth_check(self, name, already_found):
         return None
+
+    def get_attr(self, attr_name: str, indices: VecEnvIndices = None) -> List[Any]:
+        attr = self.venv.get_attr(attr_name)
+        # Note: SB3 expects render_mode to be returned as an array (TODO: they should fix this)
+        if attr_name == "render_mode":
+            return [attr for _ in range(self.num_envs)]
+        else:
+            return attr

--- a/supersuit/vector/sb3_vector_wrapper.py
+++ b/supersuit/vector/sb3_vector_wrapper.py
@@ -20,8 +20,7 @@ class SB3VecEnvWrapper(VecEnvWrapper):
 
     def step_wait(self):
         observations, rewards, terminations, truncations, infos = self.venv.step_wait()
-
-        # Note: SB3 expects dones to be an np array (TODO: they should fix this, and cast the dones to an array)
+        # Note: SB3 expects dones to be an np.array
         dones = np.array(
             [terminations[i] or truncations[i] for i in range(len(terminations))]
         )
@@ -39,7 +38,7 @@ class SB3VecEnvWrapper(VecEnvWrapper):
 
     def get_attr(self, attr_name: str, indices: VecEnvIndices = None) -> List[Any]:
         attr = self.venv.get_attr(attr_name)
-        # Note: SB3 expects render_mode to be returned as an array (TODO: they should fix this)
+        # Note: SB3 expects render_mode to be returned as an array, with values for each env
         if attr_name == "render_mode":
             return [attr for _ in range(self.num_envs)]
         else:


### PR DESCRIPTION
This solves this issue https://github.com/Farama-Foundation/SuperSuit/issues/217

Here's code to test this out:

```
from stable_baselines3.ppo import CnnPolicy
from stable_baselines3 import PPO
from pettingzoo.butterfly import pistonball_v6
import supersuit as ss

env = pistonball_v6.parallel_env(n_pistons=20, time_penalty=-0.1, continuous=True, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)

env = ss.color_reduction_v0(env, mode='B')
env = ss.resize_v1(env, x_size=84, y_size=84)
env = ss.frame_stack_v1(env, 3)


env = ss.pettingzoo_env_to_vec_env_v1(env)
env = ss.concat_vec_envs_v1(env, 8, num_cpus=4, base_class='stable_baselines3')

model = PPO(CnnPolicy, env, verbose=3, gamma=0.95, n_steps=256, ent_coef=0.0905168, learning_rate=0.00062211, vf_coef=0.042202, max_grad_norm=0.9, gae_lambda=0.99, n_epochs=5, clip_range=0.3, batch_size=256)

model.learn(total_timesteps=2000000)

model.save("policy")
```