### PR TITLE
Added a compatibility to an obs with multiple informations in aec env

### DIFF
--- a/supersuit/lambda_wrappers/observation_lambda.py
+++ b/supersuit/lambda_wrappers/observation_lambda.py
@@ -49,8 +49,12 @@ class aec_observation_lambda(BaseWrapper):
             if isinstance(modify_space, gymnasium.spaces.Dict):
                 modify_space = modify_space["observation"]
             try:
-                trans_low = self.change_observation_fn(modify_space.low, modify_space, agent)
-                trans_high = self.change_observation_fn(modify_space.high, modify_space, agent)
+                trans_low = self.change_observation_fn(
+                    modify_space.low, modify_space, agent
+                )
+                trans_high = self.change_observation_fn(
+                    modify_space.high, modify_space, agent
+                )
             except TypeError:
                 trans_low = self.change_observation_fn(modify_space.low, modify_space)
                 trans_high = self.change_observation_fn(modify_space.high, modify_space)
@@ -58,7 +62,9 @@ class aec_observation_lambda(BaseWrapper):
             new_high = np.maximum(trans_low, trans_high)
 
             if isinstance(space, gymnasium.spaces.Dict):
-                space["observation"] = Box(low=new_low, high=new_high, dtype=new_low.dtype)
+                space["observation"] = Box(
+                    low=new_low, high=new_high, dtype=new_low.dtype
+                )
                 return space
             else:
                 return Box(low=new_low, high=new_high, dtype=new_low.dtype)
@@ -71,9 +77,9 @@ class aec_observation_lambda(BaseWrapper):
                 modify_obs_space = self.change_obs_space_fn(modify_obs_space, agent)
             except TypeError:
                 modify_obs_space = self.change_obs_space_fn(modify_obs_space)
-            
+
             if isinstance(old_obs_space, gymnasium.spaces.Dict):
-                old_obs_space["observation"] = modify_obs_space 
+                old_obs_space["observation"] = modify_obs_space
             else:
                 old_obs_space = modify_obs_space
             return old_obs_space

--- a/supersuit/lambda_wrappers/observation_lambda.py
+++ b/supersuit/lambda_wrappers/observation_lambda.py
@@ -45,26 +45,38 @@ class aec_observation_lambda(BaseWrapper):
     def observation_space(self, agent):
         if self.change_obs_space_fn is None:
             space = self.env.observation_space(agent)
-            if isinstance(space, gymnasium.spaces.Dict):
-                space = space["observation"]
+            modify_space = space
+            if isinstance(modify_space, gymnasium.spaces.Dict):
+                modify_space = modify_space["observation"]
             try:
-                trans_low = self.change_observation_fn(space.low, space, agent)
-                trans_high = self.change_observation_fn(space.high, space, agent)
+                trans_low = self.change_observation_fn(modify_space.low, modify_space, agent)
+                trans_high = self.change_observation_fn(modify_space.high, modify_space, agent)
             except TypeError:
-                trans_low = self.change_observation_fn(space.low, space)
-                trans_high = self.change_observation_fn(space.high, space)
+                trans_low = self.change_observation_fn(modify_space.low, modify_space)
+                trans_high = self.change_observation_fn(modify_space.high, modify_space)
             new_low = np.minimum(trans_low, trans_high)
             new_high = np.maximum(trans_low, trans_high)
 
-            return Box(low=new_low, high=new_high, dtype=new_low.dtype)
+            if isinstance(space, gymnasium.spaces.Dict):
+                space["observation"] = Box(low=new_low, high=new_high, dtype=new_low.dtype)
+                return space
+            else:
+                return Box(low=new_low, high=new_high, dtype=new_low.dtype)
         else:
             old_obs_space = self.env.observation_space(agent)
-            if isinstance(old_obs_space, gymnasium.spaces.Dict):
-                old_obs_space = old_obs_space["observation"]
+            modify_obs_space = old_obs_space
+            if isinstance(modify_obs_space, gymnasium.spaces.Dict):
+                modify_obs_space = modify_obs_space["observation"]
             try:
-                return self.change_obs_space_fn(old_obs_space, agent)
+                modify_obs_space = self.change_obs_space_fn(modify_obs_space, agent)
             except TypeError:
-                return self.change_obs_space_fn(old_obs_space)
+                modify_obs_space = self.change_obs_space_fn(modify_obs_space)
+            
+            if isinstance(old_obs_space, gymnasium.spaces.Dict):
+                old_obs_space["observation"] = modify_obs_space 
+            else:
+                old_obs_space = modify_obs_space
+            return old_obs_space
 
     def _modify_observation(self, agent, observation):
         old_obs_space = self.env.observation_space(agent)

--- a/supersuit/lambda_wrappers/observation_lambda.py
+++ b/supersuit/lambda_wrappers/observation_lambda.py
@@ -45,6 +45,8 @@ class aec_observation_lambda(BaseWrapper):
     def observation_space(self, agent):
         if self.change_obs_space_fn is None:
             space = self.env.observation_space(agent)
+            if isinstance(space, gymnasium.spaces.Dict):
+                space = space["observation"]
             try:
                 trans_low = self.change_observation_fn(space.low, space, agent)
                 trans_high = self.change_observation_fn(space.high, space, agent)
@@ -57,6 +59,8 @@ class aec_observation_lambda(BaseWrapper):
             return Box(low=new_low, high=new_high, dtype=new_low.dtype)
         else:
             old_obs_space = self.env.observation_space(agent)
+            if isinstance(old_obs_space, gymnasium.spaces.Dict):
+                old_obs_space = old_obs_space["observation"]
             try:
                 return self.change_obs_space_fn(old_obs_space, agent)
             except TypeError:
@@ -64,6 +68,8 @@ class aec_observation_lambda(BaseWrapper):
 
     def _modify_observation(self, agent, observation):
         old_obs_space = self.env.observation_space(agent)
+        if isinstance(old_obs_space, gymnasium.spaces.Dict):
+            old_obs_space = old_obs_space["observation"]
         try:
             return self.change_observation_fn(observation, old_obs_space, agent)
         except TypeError:

--- a/supersuit/utils/base_aec_wrapper.py
+++ b/supersuit/utils/base_aec_wrapper.py
@@ -37,9 +37,10 @@ class BaseWrapper(PettingzooWrap):
         )  # problem is in this line, the obs is sometimes a different size from the obs space
         # In the case of more information in the obs
         if isinstance(obs, dict):
-            obs = obs["observation"]
-        observation = self._modify_observation(agent, obs)
-        return observation
+            obs["observation"] = self._modify_observation(agent, obs["observation"])
+        else:
+            obs = self._modify_observation(agent, obs)
+        return obs
 
     def step(self, action):
         agent = self.env.agent_selection

--- a/supersuit/utils/base_aec_wrapper.py
+++ b/supersuit/utils/base_aec_wrapper.py
@@ -35,6 +35,9 @@ class BaseWrapper(PettingzooWrap):
         obs = super().observe(
             agent
         )  # problem is in this line, the obs is sometimes a different size from the obs space
+        # In the case of more information in the obs
+        if isinstance(obs, dict):
+            obs = obs["observation"]
         observation = self._modify_observation(agent, obs)
         return observation
 


### PR DESCRIPTION
Extended support to AEC's observations of spaces.Dict.

Before, it only accepts an RGB array as the returned observation from the environment. 
Now, it can take such an observation as `obs["observation": value, "action_mask": value]`.