### PR TITLE
Fix rendering for ProcConcatVec envs

### DIFF
--- a/supersuit/vector/concat_vec_env.py
+++ b/supersuit/vector/concat_vec_env.py
@@ -25,6 +25,7 @@ class ConcatVecEnv(gymnasium.vector.VectorEnv):
             if not hasattr(vec_envs[i], "num_envs"):
                 vec_envs[i] = SingleVecEnv([lambda: vec_envs[i]])
         self.metadata = self.vec_envs[0].metadata
+        self.render_mode = self.vec_envs[0].render_mode
         self.observation_space = vec_envs[0].observation_space
         self.action_space = vec_envs[0].action_space
         tot_num_envs = sum(env.num_envs for env in vec_envs)

--- a/supersuit/vector/markov_vector_wrapper.py
+++ b/supersuit/vector/markov_vector_wrapper.py
@@ -17,6 +17,7 @@ class MarkovVectorEnv(gymnasium.vector.VectorEnv):
         """
         self.par_env = par_env
         self.metadata = par_env.metadata
+        self.render_mode = par_env.render_mode
         self.observation_space = par_env.observation_space(par_env.possible_agents[0])
         self.action_space = par_env.action_space(par_env.possible_agents[0])
         assert all(

--- a/supersuit/vector/multiproc_vec.py
+++ b/supersuit/vector/multiproc_vec.py
@@ -98,13 +98,12 @@ def async_loop(
                 elif name == "env_is_wrapped":
                     comp_infos = vec_env.env_is_wrapped(data)
 
-                elif name == "render":
-                    render_result = vec_env.render(data)
-                    if data == "rgb_array":
-                        comp_infos = render_result
-
                 else:
                     raise AssertionError("bad tuple instruction name: " + name)
+            elif instr == "render":
+                render_result = vec_env.render()
+                if vec_env.render_mode == "rgb_array":
+                    comp_infos = render_result
             elif instr == "terminate":
                 return
             else:


### PR DESCRIPTION
Since the `render()` function no longer takes a `mode` parameter, `ProcConcatVec` could not call `render()`. This is a simple PR to fix that. `mode` is replaced by the `render_mode` attribute of the vec env (which also needs to be copied from the parent env by the `ConcatVecEnv` class.

I'm unsure whether different `render_mode`s should also be returning something (e.g. should ansi render modes also return something?). With this PR I've just kept the logic the same as the previous version.