### PR TITLE
Bump Gymnasium version to 1.0.0 and fix test cases due to the version bump

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -15,10 +15,10 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,9 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install -e .[testing]
+        # Install pettingzoo directly from master until it mints a new version to resolve
+        # pygame version restriction.
+        pip install "pettingzoo[all,atari] @ git+https://github.com/Farama-Foundation/PettingZoo.git@master"
         AutoROM -v
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy>=1.19.0", "gymnasium>=0.28.1", "tinyscaler>=1.2.6"]
+dependencies = ["numpy>=1.19.0", "gymnasium>=1.0.0", "tinyscaler>=1.2.6"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name="SuperSuit"
 description="Wrappers for Gymnasium and PettingZoo"
 readme="README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords=["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -17,7 +17,6 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.8",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -26,7 +25,11 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-testing = ["pettingzoo[all,atari]>=1.23.1", "AutoROM", "pytest", "pytest-xdist", "stable-baselines3>=2.0.0", "moviepy >=1.0.0"]
+
+# Remove "pettingzoo[all,atari]" from dependencies for now
+# as there's a pygame version mismatch issue for pettingzoo version
+# 1.24.3. Once pettingzoo gets an updated version, add it back.
+testing = ["AutoROM", "pytest", "pytest-xdist", "stable-baselines3>=2.0.0", "moviepy >=1.0.0"]
 
 [project.urls]
 Homepage = "https://farama.org"
@@ -60,7 +63,7 @@ exclude = ["**/node_modules", "**/__pycache__"]
 strict = []
 
 typeCheckingMode = "basic"
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 pythonPlatform = "All"
 typeshedPath = "typeshed"
 enableTypeIgnoreComments = true

--- a/supersuit/vector/vector_constructors.py
+++ b/supersuit/vector/vector_constructors.py
@@ -12,7 +12,7 @@ def vec_env_args(env, num_envs):
         env_copy = cloudpickle.loads(cloudpickle.dumps(env))
         return env_copy
 
-    return [env_fn] * num_envs, env.observation_space, env.action_space
+    return ([env_fn] * num_envs,)
 
 
 def warn_not_gym_env(env, fn_name):

--- a/test/test_vector/test_pettingzoo_to_vec_gymnasium_wrappers.py
+++ b/test/test_vector/test_pettingzoo_to_vec_gymnasium_wrappers.py
@@ -1,6 +1,7 @@
+import gymnasium as gym
 import numpy as np
 import pytest
-from gymnasium.wrappers import normalize
+from gymnasium.wrappers import NormalizeObservation
 from pettingzoo.butterfly import pistonball_v6
 
 import supersuit as ss
@@ -13,7 +14,14 @@ def test_vec_env_normalize_obs(env_fn):
     env = ss.concat_vec_envs_v1(env, 10, base_class="gymnasium")
     obs, info = env.reset()
 
-    env = normalize.NormalizeObservation(env)
+    # Create a "dummy" class that adds gym.Env as a base class of the env
+    # to satisfy the assertion.
+    class PatchedEnv(env.__class__, gym.Env):
+        pass
+
+    env.__class__ = PatchedEnv
+
+    env = NormalizeObservation(env)
     normalized_obs, normalized_info = env.reset()
 
     obs_range = np.amax(obs) - np.amin(obs)


### PR DESCRIPTION
This PR bumps up the minimum gymnasium version to 1.0.0 and fixes test cases due to the version change.

For the diff in supersuit/vector/vector_constructors.py, in gymnasium's SyncVectorEnv's constructor argument has changed so that it'll implicitly infer the environment's observation space and action space by default, so we don't need to pass them as arguments anymore.

For the diff in test/test_vector/test_pettingzoo_to_vec_gymnasium_wrappers.py, we see a similar issue we saw in PettingZoo in https://github.com/Farama-Foundation/PettingZoo/pull/1272, where gymnasium now requires env's passed into its wrappers to be under the base class `gym.Env`. As a quick and dirty workaround, we dynamically add gym.Env as its base class.