### PR TITLE
Support Dict observation spaces in frame_stack

### DIFF
--- a/supersuit/generic_wrappers/frame_stack.py
+++ b/supersuit/generic_wrappers/frame_stack.py
@@ -1,4 +1,4 @@
-from gymnasium.spaces import Box, Discrete
+from gymnasium.spaces import Box, Dict, Discrete
 
 from supersuit.utils.frame_stack import stack_init, stack_obs, stack_obs_space
 
@@ -6,23 +6,35 @@ from .utils.base_modifier import BaseModifier
 from .utils.shared_wrapper_util import shared_wrapper
 
 
+def check_stackable(obs_space):
+    """Assert that obs_space can be frame stacked.
+
+    Dict spaces are checked recursively, so a Dict is stackable exactly when
+    every one of its subspaces is.
+    """
+    if isinstance(obs_space, Box):
+        assert (
+            1 <= len(obs_space.shape) <= 3
+        ), "frame_stack only works for 1, 2 or 3 dimensional observations"
+    elif isinstance(obs_space, Discrete):
+        pass
+    elif isinstance(obs_space, Dict):
+        for subspace in obs_space.spaces.values():
+            check_stackable(subspace)
+    else:
+        assert (
+            False
+        ), "Stacking is currently only allowed for Box, Discrete and Dict observation spaces. The given observation space is {}".format(
+            obs_space
+        )
+
+
 def frame_stack_v1(env, stack_size=4, stack_dim=-1):
     assert isinstance(stack_size, int), "stack size of frame_stack must be an int"
 
     class FrameStackModifier(BaseModifier):
         def modify_obs_space(self, obs_space):
-            if isinstance(obs_space, Box):
-                assert (
-                    1 <= len(obs_space.shape) <= 3
-                ), "frame_stack only works for 1, 2 or 3 dimensional observations"
-            elif isinstance(obs_space, Discrete):
-                pass
-            else:
-                assert (
-                    False
-                ), "Stacking is currently only allowed for Box and Discrete observation spaces. The given observation space is {}".format(
-                    obs_space
-                )
+            check_stackable(obs_space)
 
             self.old_obs_space = obs_space
             self.observation_space = stack_obs_space(obs_space, stack_size, stack_dim)
@@ -50,18 +62,7 @@ def frame_stack_v2(env, stack_size=4, stack_dim=-1):
 
     class FrameStackModifier(BaseModifier):
         def modify_obs_space(self, obs_space):
-            if isinstance(obs_space, Box):
-                assert (
-                    1 <= len(obs_space.shape) <= 3
-                ), "frame_stack only works for 1, 2 or 3 dimensional observations"
-            elif isinstance(obs_space, Discrete):
-                pass
-            else:
-                assert (
-                    False
-                ), "Stacking is currently only allowed for Box and Discrete observation spaces. The given observation space is {}".format(
-                    obs_space
-                )
+            check_stackable(obs_space)
 
             self.old_obs_space = obs_space
             self.observation_space = stack_obs_space(obs_space, stack_size, stack_dim)

--- a/supersuit/utils/frame_stack.py
+++ b/supersuit/utils/frame_stack.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gymnasium.spaces import Box, Discrete
+from gymnasium.spaces import Box, Dict, Discrete
 
 
 def get_tile_shape(shape, stack_size, stack_dim=-1):
@@ -56,10 +56,17 @@ def stack_obs_space(obs_space, stack_size, stack_dim=-1):
         return new_obs_space
     elif isinstance(obs_space, Discrete):
         return Discrete(obs_space.n**stack_size)
+    elif isinstance(obs_space, Dict):
+        return Dict(
+            {
+                name: stack_obs_space(subspace, stack_size, stack_dim)
+                for name, subspace in obs_space.spaces.items()
+            }
+        )
     else:
         assert (
             False
-        ), "Stacking is currently only allowed for Box and Discrete observation spaces. The given observation space is {}".format(
+        ), "Stacking is currently only allowed for Box, Discrete and Dict observation spaces. The given observation space is {}".format(
             obs_space
         )
 
@@ -70,6 +77,11 @@ def stack_init(obs_space, stack_size, stack_dim=-1):
             obs_space.low.shape, stack_size, stack_dim
         )
         return np.tile(np.zeros(new_shape, dtype=obs_space.dtype), tile_shape)
+    elif isinstance(obs_space, Dict):
+        return {
+            name: stack_init(subspace, stack_size, stack_dim)
+            for name, subspace in obs_space.spaces.items()
+        }
     else:
         return 0
 
@@ -115,3 +127,11 @@ def stack_obs(frame_stack, obs, obs_space, stack_size, stack_dim=-1):
 
     elif isinstance(obs_space, Discrete):
         return (frame_stack * obs_space.n + obs) % (obs_space.n**stack_size)
+
+    elif isinstance(obs_space, Dict):
+        return {
+            name: stack_obs(
+                frame_stack[name], obs[name], subspace, stack_size, stack_dim
+            )
+            for name, subspace in obs_space.spaces.items()
+        }

--- a/test/test_utils/test_frame_stack.py
+++ b/test/test_utils/test_frame_stack.py
@@ -1,5 +1,6 @@
 import numpy as np
-from gymnasium.spaces import Box, Discrete
+import pytest
+from gymnasium.spaces import Box, Dict, Discrete
 
 from supersuit.utils.frame_stack import stack_init, stack_obs, stack_obs_space
 
@@ -9,6 +10,13 @@ stack_obs_space_2d = Box(low=np.float32(0.0), high=np.float32(1.0), shape=(4, 3)
 stack_obs_space_1d = Box(low=np.float32(0.0), high=np.float32(1.0), shape=(3,))
 
 stack_discrete = Discrete(3)
+
+stack_obs_space_dict = Dict(
+    {
+        "camera": stack_obs_space_3d,
+        "position": stack_obs_space_1d,
+    }
+)
 
 STACK_SIZE = 11
 
@@ -81,3 +89,50 @@ def test_change_observation():
         axis=2,
     )
     assert np.all(np.equal(stacked, raw))
+
+
+def test_dict_obs_space():
+    stacked_space = stack_obs_space(stack_obs_space_dict, STACK_SIZE)
+    assert isinstance(stacked_space, Dict)
+    assert set(stacked_space.spaces) == {"camera", "position"}
+    assert stacked_space["camera"].shape == (4, 4, 3 * STACK_SIZE)
+    assert stacked_space["position"].shape == (3 * STACK_SIZE,)
+    assert stacked_space["camera"].dtype == stack_obs_space_3d.dtype
+
+
+def test_dict_nested_obs_space():
+    nested = Dict({"sensors": stack_obs_space_dict, "flat": stack_obs_space_1d})
+    stacked_space = stack_obs_space(nested, STACK_SIZE)
+    assert stacked_space["sensors"]["camera"].shape == (4, 4, 3 * STACK_SIZE)
+    assert stacked_space["flat"].shape == (3 * STACK_SIZE,)
+
+
+def test_dict_init():
+    stack = stack_init(stack_obs_space_dict, STACK_SIZE)
+    assert set(stack) == {"camera", "position"}
+    assert stack["camera"].shape == (4, 4, 3 * STACK_SIZE)
+    assert stack["position"].shape == (3 * STACK_SIZE,)
+    assert np.all(stack["camera"] == 0)
+
+
+def test_dict_change_observation():
+    """A Dict stack must match stacking each subspace independently."""
+    obs_lo = {"camera": stack_obs_space_3d.low, "position": stack_obs_space_1d.low}
+    obs_hi = {"camera": stack_obs_space_3d.high, "position": stack_obs_space_1d.high}
+
+    stacked = stack_obs_helper([obs_lo, obs_hi], stack_obs_space_dict, 3)
+
+    for key, subspace in stack_obs_space_dict.spaces.items():
+        expected = stack_obs_helper([obs_lo[key], obs_hi[key]], subspace, 3)
+        assert np.all(np.equal(stacked[key], expected))
+
+    assert stacked["camera"].shape == (4, 4, 3 * 3)
+    assert stacked["position"].shape == (3 * 3,)
+
+
+def test_dict_rejects_unstackable_subspace():
+    from gymnasium.spaces import MultiBinary
+
+    bad = Dict({"ok": stack_obs_space_1d, "bad": MultiBinary(4)})
+    with pytest.raises(AssertionError):
+        stack_obs_space(bad, STACK_SIZE)


### PR DESCRIPTION
## Description

`frame_stack_v1` and `frame_stack_v2` reject `Dict` observation spaces:

```
Stacking is currently only allowed for Box and Discrete observation spaces.
```

So if an agent observes more than one thing at once, say a camera image plus a
position vector, you have to flatten it before stacking. That works but you lose
the per-key shapes, and a policy with a separate encoder per key has to slice
them back out of the flat array by hand.

This adds `Dict` support. `stack_obs_space`, `stack_init` and `stack_obs` recurse
into `Dict` and run each subspace through the existing code, so a `Dict` is
stackable when all its subspaces are, each key stacks the same as it would on its
own, and nested `Dict`s work too. `Box` and `Discrete` are untouched.

The validation was duplicated word for word in `frame_stack_v1` and
`frame_stack_v2`, so I pulled it into one `check_stackable()` that recurses for
`Dict`.

I hit this on a vision-based multi-agent setup (PettingZoo + SuperSuit + SB3 over
AirSim/UE4) where each drone sees an RGB frame and its own 3D position.

## Testing

Five tests in `test/test_utils/test_frame_stack.py`: stacked shapes and dtype per
key, nested `Dict`, `stack_init` zeroing, a check that stacking a `Dict` matches
stacking each subspace separately, and that a `Dict` holding a `MultiBinary`
still raises.

Full suite against `main` as a baseline:

| | result |
|---|---|
| `main` | 117 passed, 46 skipped |
| this branch | 122 passed, 46 skipped |

Difference is only the five new tests.

I also ran just the `frame_stack` and `black_death` tests from
`test/pettingzoo_api_test.py`, which are parametrized over atari, butterfly,
classic, mpe and sisl. Identical 123 passed, 51 skipped on `main` and on this
branch, so nothing changes for existing environments.

## One thing I left alone

In `stack_obs`, the 2-D `stack_dim=0` branch does:

```python
agent_fs[:-1] = agent_fs[1:]
agent_fs[:-1] = obs
```

That second line looks like it should be `agent_fs[-1:]`, matching the 1-D and
3-D branches. I did not touch it, to keep this PR to one thing. The `Dict` path
recurses through the same code so it behaves the same way either way. Happy to
file it separately if you want.
